### PR TITLE
docs(README): correct extension installation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Features include:
 ## Install
 
 To install or upgrade: open Freelens and go to Extensions (`ctrl`+`shift`+`E`
-or `cmd`+`shift`+`E`), and install `@freelensapp/fluxcd-extension`.
+or `cmd`+`shift`+`E`), and install `@freelensapp/extension-fluxcd`.
 
 or:
 
 Use a following URL in the browser:
-[freelens://app/extensions/install/%40freelensapp%2Ffluxcd-extension](freelens://app/extensions/install/%40freelensapp%2Ffluxcd-extension)
+[freelens://app/extensions/install/%40freelensapp%2Fextension-fluxcd](freelens://app/extensions/install/%40freelensapp%2Fextension-fluxcd)
 
 ## Build from the source
 


### PR DESCRIPTION
## Description
Previously, the documentation referred to @freelensapp/fluxcd-extension, but since 0d48ac8a506b6ed975b50ad93af17a60c054808b the package name is now [@freelensapp/extension-fluxcd](https://www.npmjs.com/package/@freelensapp/extension-fluxcd).

## Related

Fixes #58 
Fixes #55