### PR TITLE
Update endpoints to crds of flux 2.7

### DIFF
--- a/src/renderer/k8s/fluxcd/helm/helmrelease.ts
+++ b/src/renderer/k8s/fluxcd/helm/helmrelease.ts
@@ -220,10 +220,10 @@ export class HelmRelease extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "HelmRelease";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/helm.toolkit.fluxcd.io/v2beta1/helmreleases";
+  static readonly apiBase = "/apis/helm.toolkit.fluxcd.io/v2/helmreleases";
 
   static readonly crd: FluxCDKubeObjectCRD = {
-    apiVersions: ["helm.toolkit.fluxcd.io/v2beta1", "helm.toolkit.fluxcd.io/v2beta2", "helm.toolkit.fluxcd.io/v2"],
+    apiVersions: ["helm.toolkit.fluxcd.io/v2"],
     plural: "helmreleases",
     singular: "helmrelease",
     shortNames: ["hr"],

--- a/src/renderer/k8s/fluxcd/image/imagepolicy.ts
+++ b/src/renderer/k8s/fluxcd/image/imagepolicy.ts
@@ -42,10 +42,10 @@ export class ImagePolicy extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "ImagePolicy";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/image.toolkit.fluxcd.io/v1beta1/imagepolicies";
+  static readonly apiBase = "/apis/image.toolkit.fluxcd.io/v1/imagepolicies";
 
   static readonly crd = {
-    apiVersions: ["image.toolkit.fluxcd.io/v1beta1", "image.toolkit.fluxcd.io/v1beta2"],
+    apiVersions: ["image.toolkit.fluxcd.io/v1"],
     plural: "imagepolicies",
     singular: "imagepolicy",
     shortNames: [],

--- a/src/renderer/k8s/fluxcd/image/imagerepository.ts
+++ b/src/renderer/k8s/fluxcd/image/imagerepository.ts
@@ -35,10 +35,10 @@ export class ImageRepository extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "ImageRepository";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/image.toolkit.fluxcd.io/v1beta1/imagerepositories";
+  static readonly apiBase = "/apis/image.toolkit.fluxcd.io/v1/imagerepositories";
 
   static readonly crd = {
-    apiVersions: ["image.toolkit.fluxcd.io/v1beta1", "image.toolkit.fluxcd.io/v1beta2"],
+    apiVersions: ["image.toolkit.fluxcd.io/v1"],
     plural: "imagerepositories",
     singular: "imagerepository",
     shortNames: [],

--- a/src/renderer/k8s/fluxcd/image/imageupdateautomation.ts
+++ b/src/renderer/k8s/fluxcd/image/imageupdateautomation.ts
@@ -70,10 +70,10 @@ export class ImageUpdateAutomation extends Renderer.K8sApi.LensExtensionKubeObje
 > {
   static readonly kind = "ImageUpdateAutomation";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations";
+  static readonly apiBase = "/apis/image.toolkit.fluxcd.io/v1/imageupdateautomations";
 
   static readonly crd = {
-    apiVersions: ["image.toolkit.fluxcd.io/v1beta1", "image.toolkit.fluxcd.io/v1beta2"],
+    apiVersions: ["image.toolkit.fluxcd.io/v1"],
     plural: "imageupdateautomations",
     singular: "imageupdateautomation",
     shortNames: [],

--- a/src/renderer/k8s/fluxcd/kustomize/kustomization.ts
+++ b/src/renderer/k8s/fluxcd/kustomize/kustomization.ts
@@ -71,12 +71,10 @@ export class Kustomization extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "Kustomization";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/kustomize.toolkit.fluxcd.io/v1beta1/kustomizations";
+  static readonly apiBase = "/apis/kustomize.toolkit.fluxcd.io/v1/kustomizations";
 
   static readonly crd: FluxCDKubeObjectCRD = {
     apiVersions: [
-      "kustomize.toolkit.fluxcd.io/v1beta1",
-      "kustomize.toolkit.fluxcd.io/v1beta2",
       "kustomize.toolkit.fluxcd.io/v1",
     ],
     plural: "kustomizations",

--- a/src/renderer/k8s/fluxcd/notification/alert.ts
+++ b/src/renderer/k8s/fluxcd/notification/alert.ts
@@ -24,13 +24,11 @@ export class Alert extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "Alert";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/notification.toolkit.fluxcd.io/v1beta1/alerts";
+  static readonly apiBase = "/apis/notification.toolkit.fluxcd.io/v1/alerts";
 
   static readonly crd = {
     apiVersions: [
-      "notification.toolkit.fluxcd.io/v1beta1",
-      "notification.toolkit.fluxcd.io/v1beta2",
-      "notification.toolkit.fluxcd.io/v1beta3",
+      "notification.toolkit.fluxcd.io/v1",
     ],
     plural: "alerts",
     singular: "alert",

--- a/src/renderer/k8s/fluxcd/notification/provider.ts
+++ b/src/renderer/k8s/fluxcd/notification/provider.ts
@@ -46,13 +46,11 @@ export class Provider extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "Provider";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/notification.toolkit.fluxcd.io/v1beta1/providers";
+  static readonly apiBase = "/apis/notification.toolkit.fluxcd.io/v1/providers";
 
   static readonly crd = {
     apiVersions: [
-      "notification.toolkit.fluxcd.io/v1beta1",
-      "notification.toolkit.fluxcd.io/v1beta2",
-      "notification.toolkit.fluxcd.io/v1beta3",
+      "notification.toolkit.fluxcd.io/v1",
     ],
     plural: "providers",
     singular: "provider",

--- a/src/renderer/k8s/fluxcd/notification/receiver.ts
+++ b/src/renderer/k8s/fluxcd/notification/receiver.ts
@@ -34,13 +34,10 @@ export class Receiver extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "Receiver";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/notification.toolkit.fluxcd.io/v1beta1/receivers";
+  static readonly apiBase = "/apis/notification.toolkit.fluxcd.io/v1/receivers";
 
   static readonly crd = {
     apiVersions: [
-      "notification.toolkit.fluxcd.io/v1beta1",
-      "notification.toolkit.fluxcd.io/v1beta2",
-      "notification.toolkit.fluxcd.io/v1beta3",
       "notification.toolkit.fluxcd.io/v1",
     ],
     plural: "receivers",

--- a/src/renderer/k8s/fluxcd/source/bucket.ts
+++ b/src/renderer/k8s/fluxcd/source/bucket.ts
@@ -28,13 +28,11 @@ export class Bucket extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "Bucket";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1beta1/buckets";
+  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1beta2/buckets";
 
   static readonly crd = {
     apiVersions: [
-      "source.toolkit.fluxcd.io/v1beta1",
       "source.toolkit.fluxcd.io/v1beta2",
-      "source.toolkit.fluxcd.io/v1",
     ],
     plural: "buckets",
     singular: "bucket",

--- a/src/renderer/k8s/fluxcd/source/gitrepository.ts
+++ b/src/renderer/k8s/fluxcd/source/gitrepository.ts
@@ -46,12 +46,10 @@ export class GitRepository extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "GitRepository";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1beta1/gitrepositories";
+  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1/gitrepositories";
 
   static readonly crd = {
     apiVersions: [
-      "source.toolkit.fluxcd.io/v1beta1",
-      "source.toolkit.fluxcd.io/v1beta2",
       "source.toolkit.fluxcd.io/v1",
     ],
     plural: "gitrepositories",

--- a/src/renderer/k8s/fluxcd/source/helmchart.ts
+++ b/src/renderer/k8s/fluxcd/source/helmchart.ts
@@ -32,12 +32,10 @@ export class HelmChart extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "HelmChart";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1beta1/helmrepositories";
+  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1/helmcharts";
 
   static readonly crd = {
     apiVersions: [
-      "source.toolkit.fluxcd.io/v1beta1",
-      "source.toolkit.fluxcd.io/v1beta2",
       "source.toolkit.fluxcd.io/v1",
     ],
     plural: "helmcharts",

--- a/src/renderer/k8s/fluxcd/source/helmrepository.ts
+++ b/src/renderer/k8s/fluxcd/source/helmrepository.ts
@@ -42,12 +42,10 @@ export class HelmRepository extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "HelmRepository";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1beta1/helmrepositories";
+  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1/helmrepositories";
 
   static readonly crd = {
     apiVersions: [
-      "source.toolkit.fluxcd.io/v1beta1",
-      "source.toolkit.fluxcd.io/v1beta2",
       "source.toolkit.fluxcd.io/v1",
     ],
     plural: "helmrepositories",

--- a/src/renderer/k8s/fluxcd/source/ocirepository.ts
+++ b/src/renderer/k8s/fluxcd/source/ocirepository.ts
@@ -58,10 +58,10 @@ export class OCIRepository extends Renderer.K8sApi.LensExtensionKubeObject<
 > {
   static readonly kind = "OCIRepository";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1beta2/ocirepositories";
+  static readonly apiBase = "/apis/source.toolkit.fluxcd.io/v1/ocirepositories";
 
   static readonly crd = {
-    apiVersions: ["source.toolkit.fluxcd.io/v1beta2", "source.toolkit.fluxcd.io/v1"],
+    apiVersions: ["source.toolkit.fluxcd.io/v1"],
     plural: "ocirepositories",
     singular: "ocirepository",
     shortNames: ["ocirepo"],


### PR DESCRIPTION
Updated endpoints for extention to work, not yet new functionality of source watcher.