### PR TITLE
Correct links from the overview

### DIFF
--- a/src/renderer/components/pie-chart.tsx
+++ b/src/renderer/components/pie-chart.tsx
@@ -29,7 +29,7 @@ const getStats = (
 };
 
 const getPath = (crd: Renderer.K8sApi.CustomResourceDefinition) => {
-  return crd.spec.names.plural;
+  return crd.spec.names.singular;
 };
 
 export interface PieChartProps<A extends Renderer.K8sApi.KubeObject> {


### PR DESCRIPTION
Fixes #164 

This pull request makes a small change to the `getPath` function in `src/renderer/components/pie-chart.tsx`. The function now returns the singular name instead of the plural name from the custom resource definition.
