### PR TITLE
docs: add migration instructions from old package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ or:
 Use a following URL in the browser:
 [freelens://app/extensions/install/%40freelensapp%2Ffluxcd-extension](freelens://app/extensions/install/%40freelensapp%2Ffluxcd-extension)
 
+### Migrating from `@freelensapp/extension-fluxcd`
+
+The package was renamed from `@freelensapp/extension-fluxcd` to
+`@freelensapp/fluxcd-extension` starting with v4.0.0.
+
+If you have the old package installed, you will not receive updates and may
+encounter issues with newer Flux versions (e.g., Flux 2.7+ which removed
+v1beta1 APIs).
+
+To migrate:
+
+1. Open Freelens Extensions (`ctrl`+`shift`+`E` or `cmd`+`shift`+`E`)
+2. Uninstall `@freelensapp/extension-fluxcd` (the old package)
+3. Install `@freelensapp/fluxcd-extension` (the new package)
+
 ## Requirements
 
 - Kubernetes >= 1.24


### PR DESCRIPTION
## Summary

- Add migration instructions for users upgrading from the old package name (`@freelensapp/extension-fluxcd`) to the new name (`@freelensapp/fluxcd-extension`)

The package was renamed in v4.0.0, but users searching for "fluxcd" in Freelens may still find and install the old package (v3.2.0), which:
- Does not receive updates
- Has issues with Flux 2.7+ (v1beta1 APIs removed)

## Context

Relates to #185 - Users on Flux 2.7+ clusters with only v1 APIs were encountering errors because the old package (v3.2.0) has hardcoded v1beta1 API paths.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify migration steps are accurate