### PR TITLE
Fix typo in tooltip label for pie chart

### DIFF
--- a/src/renderer/components/pie-chart.tsx
+++ b/src/renderer/components/pie-chart.tsx
@@ -54,7 +54,7 @@ export function PieChart(
         tooltipLabels: [
           (percent) => `Ready: ${percent}`,
           (percent) => `Not Ready: ${percent}`,
-          (percent) => `In pogress: ${percent}`,
+          (percent) => `In progress: ${percent}`,
           (percent) => `Suspended: ${percent}`,
           (percent) => `Unknown: ${percent}`,
         ],


### PR DESCRIPTION
Duplicates #222 as I can't rebase to the original PR's repo