### PR TITLE
Vite 8 is more strict about types from externalized modules

### DIFF
--- a/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
@@ -8,9 +8,9 @@ import { StatusInventory } from "../../status-inventory";
 import styles from "./flux-instance-details.module.scss";
 import stylesInline from "./flux-instance-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { FluxInstance } from "../../../k8s/fluxcd/controlplane/fluxinstance-v1";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { checksum, createEnumFromKeys } from "../../../utils";
 import { SpecPatches } from "../../spec-patches";
@@ -7,6 +7,8 @@ import { StatusHistory } from "../../status-history";
 import { StatusInventory } from "../../status-inventory";
 import styles from "./flux-instance-details.module.scss";
 import stylesInline from "./flux-instance-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { FluxInstance } from "../../../k8s/fluxcd/controlplane/fluxinstance-v1";
 

--- a/src/renderer/components/details/controlplane/flux-report-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/flux-report-details-v1.tsx
@@ -5,9 +5,9 @@ import { checksum, createEnumFromKeys } from "../../../utils";
 import styles from "./flux-report-details.module.scss";
 import stylesInline from "./flux-report-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { FluxReconcilerStatus, FluxReport } from "../../../k8s/fluxcd/controlplane/fluxreport-v1";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/controlplane/flux-report-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/flux-report-details-v1.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { checksum, createEnumFromKeys } from "../../../utils";
 import styles from "./flux-report-details.module.scss";
 import stylesInline from "./flux-report-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { FluxReconcilerStatus, FluxReport } from "../../../k8s/fluxcd/controlplane/fluxreport-v1";
 

--- a/src/renderer/components/details/controlplane/resource-set-details.tsx
+++ b/src/renderer/components/details/controlplane/resource-set-details.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { checksum } from "../../../utils";
 import { StatusHistory } from "../../status-history";
@@ -7,6 +7,8 @@ import { StatusInventory } from "../../status-inventory";
 import { YamlDump } from "../../yaml-dump";
 import styles from "./resource-set-details.module.scss";
 import stylesInline from "./resource-set-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { ResourceSet } from "../../../k8s/fluxcd/controlplane/resourceset-v1";
 

--- a/src/renderer/components/details/controlplane/resource-set-details.tsx
+++ b/src/renderer/components/details/controlplane/resource-set-details.tsx
@@ -8,9 +8,9 @@ import { YamlDump } from "../../yaml-dump";
 import styles from "./resource-set-details.module.scss";
 import stylesInline from "./resource-set-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { ResourceSet } from "../../../k8s/fluxcd/controlplane/resourceset-v1";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/controlplane/resource-set-input-provider-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/resource-set-input-provider-details-v1.tsx
@@ -6,9 +6,9 @@ import { YamlDump } from "../../yaml-dump";
 import styles from "./resource-set-input-provider-details.module.scss";
 import stylesInline from "./resource-set-input-provider-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { ResourceSetInputProvider, Schedule } from "../../../k8s/fluxcd/controlplane/resourcesetinputprovider-v1";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/controlplane/resource-set-input-provider-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/resource-set-input-provider-details-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { checksum, createEnumFromKeys } from "../../../utils";
 import { YamlDump } from "../../yaml-dump";
 import styles from "./resource-set-input-provider-details.module.scss";
 import stylesInline from "./resource-set-input-provider-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { ResourceSetInputProvider, Schedule } from "../../../k8s/fluxcd/controlplane/resourcesetinputprovider-v1";
 

--- a/src/renderer/components/details/helm/helm-release-details-v2.tsx
+++ b/src/renderer/components/details/helm/helm-release-details-v2.tsx
@@ -9,9 +9,9 @@ import { SpecPatches } from "../../spec-patches";
 import styles from "./helm-release-details.module.scss";
 import stylesInline from "./helm-release-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { Patch } from "../../../k8s/core/types";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/components/details/helm/helm-release-details-v2.tsx
+++ b/src/renderer/components/details/helm/helm-release-details-v2.tsx
@@ -1,13 +1,15 @@
 import { Common, Renderer } from "@freelensapp/extensions";
 import { Base64 } from "js-base64";
 import yaml from "js-yaml";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { useEffect, useState } from "react";
 import { HelmRelease, HelmReleaseSnapshot } from "../../../k8s/fluxcd/helm/helmrelease-v2";
 import { createEnumFromKeys, defaultYamlDumpOptions, getHeight, getMaybeDetailsUrl } from "../../../utils";
 import { SpecPatches } from "../../spec-patches";
 import styles from "./helm-release-details.module.scss";
 import stylesInline from "./helm-release-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { Patch } from "../../../k8s/core/types";
 

--- a/src/renderer/components/details/helm/helm-release-details-v2beta1.tsx
+++ b/src/renderer/components/details/helm/helm-release-details-v2beta1.tsx
@@ -9,9 +9,9 @@ import { SpecPatches } from "../../spec-patches";
 import styles from "./helm-release-details.module.scss";
 import stylesInline from "./helm-release-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { Patch } from "../../../k8s/core/types";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/components/details/helm/helm-release-details-v2beta1.tsx
+++ b/src/renderer/components/details/helm/helm-release-details-v2beta1.tsx
@@ -1,13 +1,15 @@
 import { Common, Renderer } from "@freelensapp/extensions";
 import { Base64 } from "js-base64";
 import yaml from "js-yaml";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { useEffect, useState } from "react";
 import { HelmRelease, HelmReleaseSnapshot } from "../../../k8s/fluxcd/helm/helmrelease-v2beta1";
 import { createEnumFromKeys, defaultYamlDumpOptions, getHeight, getMaybeDetailsUrl } from "../../../utils";
 import { SpecPatches } from "../../spec-patches";
 import styles from "./helm-release-details.module.scss";
 import stylesInline from "./helm-release-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { Patch } from "../../../k8s/core/types";
 

--- a/src/renderer/components/details/helm/helm-release-details-v2beta2.tsx
+++ b/src/renderer/components/details/helm/helm-release-details-v2beta2.tsx
@@ -9,9 +9,9 @@ import { SpecPatches } from "../../spec-patches";
 import styles from "./helm-release-details.module.scss";
 import stylesInline from "./helm-release-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { Patch } from "../../../k8s/core/types";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/components/details/helm/helm-release-details-v2beta2.tsx
+++ b/src/renderer/components/details/helm/helm-release-details-v2beta2.tsx
@@ -1,13 +1,15 @@
 import { Common, Renderer } from "@freelensapp/extensions";
 import { Base64 } from "js-base64";
 import yaml from "js-yaml";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { useEffect, useState } from "react";
 import { HelmRelease, HelmReleaseSnapshot } from "../../../k8s/fluxcd/helm/helmrelease-v2beta2";
 import { createEnumFromKeys, defaultYamlDumpOptions, getHeight, getMaybeDetailsUrl } from "../../../utils";
 import { SpecPatches } from "../../spec-patches";
 import styles from "./helm-release-details.module.scss";
 import stylesInline from "./helm-release-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { Patch } from "../../../k8s/core/types";
 

--- a/src/renderer/components/details/image/image-policy-details-v1.tsx
+++ b/src/renderer/components/details/image/image-policy-details-v1.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImagePolicy } from "../../../k8s/fluxcd/image/imagepolicy-v1";
+
+const { observer } = MobxReact;
 
 const {
   Component: { DrawerItem, LinkToObject },

--- a/src/renderer/components/details/image/image-policy-details-v1beta1.tsx
+++ b/src/renderer/components/details/image/image-policy-details-v1beta1.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImagePolicy } from "../../../k8s/fluxcd/image/imagepolicy-v1beta1";
+
+const { observer } = MobxReact;
 
 const {
   Component: { DrawerItem, LinkToObject },

--- a/src/renderer/components/details/image/image-policy-details-v1beta2.tsx
+++ b/src/renderer/components/details/image/image-policy-details-v1beta2.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImagePolicy } from "../../../k8s/fluxcd/image/imagepolicy-v1beta2";
+
+const { observer } = MobxReact;
 
 const {
   Component: { DrawerItem, LinkToObject },

--- a/src/renderer/components/details/image/image-repository-details-v1.tsx
+++ b/src/renderer/components/details/image/image-repository-details-v1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImageRepository } from "../../../k8s/fluxcd/image/imagerepository-v1";
 import { SpecAccessFrom } from "../../spec-access-from";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, DurationAbsoluteTimestamp, LinkToSecret, LinkToServiceAccount },

--- a/src/renderer/components/details/image/image-repository-details-v1beta1.tsx
+++ b/src/renderer/components/details/image/image-repository-details-v1beta1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImageRepository } from "../../../k8s/fluxcd/image/imagerepository-v1beta1";
 import { SpecAccessFrom } from "../../spec-access-from";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, DurationAbsoluteTimestamp, LinkToSecret, LinkToServiceAccount },

--- a/src/renderer/components/details/image/image-repository-details-v1beta2.tsx
+++ b/src/renderer/components/details/image/image-repository-details-v1beta2.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImageRepository } from "../../../k8s/fluxcd/image/imagerepository-v1beta2";
 import { SpecAccessFrom } from "../../spec-access-from";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, DurationAbsoluteTimestamp, LinkToSecret, LinkToServiceAccount },

--- a/src/renderer/components/details/image/image-update-automation-details-v1.tsx
+++ b/src/renderer/components/details/image/image-update-automation-details-v1.tsx
@@ -1,11 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImageUpdateAutomation } from "../../../k8s/fluxcd/image/imageupdateautomation-v1";
 import { GitRepository } from "../../../k8s/fluxcd/source/gitrepository-v1";
 import { getHeight } from "../../../utils";
 import styles from "./image-update-automation-details.module.scss";
 import stylesInline from "./image-update-automation-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, Icon, LinkToObject, LinkToSecret, MonacoEditor },

--- a/src/renderer/components/details/image/image-update-automation-details-v1beta1.tsx
+++ b/src/renderer/components/details/image/image-update-automation-details-v1beta1.tsx
@@ -1,11 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImageUpdateAutomation } from "../../../k8s/fluxcd/image/imageupdateautomation-v1beta1";
 import { GitRepository } from "../../../k8s/fluxcd/source/gitrepository-v1";
 import { getHeight } from "../../../utils";
 import styles from "./image-update-automation-details.module.scss";
 import stylesInline from "./image-update-automation-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, MonacoEditor, LinkToObject, LinkToSecret },

--- a/src/renderer/components/details/image/image-update-automation-details-v1beta2.tsx
+++ b/src/renderer/components/details/image/image-update-automation-details-v1beta2.tsx
@@ -1,11 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { ImageUpdateAutomation } from "../../../k8s/fluxcd/image/imageupdateautomation-v1beta2";
 import { GitRepository } from "../../../k8s/fluxcd/source/gitrepository-v1";
 import { getHeight } from "../../../utils";
 import styles from "./image-update-automation-details.module.scss";
 import stylesInline from "./image-update-automation-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, Icon, LinkToObject, LinkToSecret, MonacoEditor },

--- a/src/renderer/components/details/kustomize/kustomization-details-v1.tsx
+++ b/src/renderer/components/details/kustomize/kustomization-details-v1.tsx
@@ -2,7 +2,7 @@ import { Common, Renderer } from "@freelensapp/extensions";
 import crypto from "crypto";
 import { Base64 } from "js-base64";
 import yaml from "js-yaml";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { useEffect, useState } from "react";
 import { Kustomization, type KustomizationStore } from "../../../k8s/fluxcd/kustomize/kustomization-v1";
 import { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
@@ -14,6 +14,8 @@ import { getConditionClass, getConditionText, getStatusMessage } from "../../sta
 import { StatusInventory } from "../../status-inventory";
 import styles from "./kustomization-details.module.scss";
 import stylesInline from "./kustomization-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/kustomize/kustomization-details-v1beta1.tsx
+++ b/src/renderer/components/details/kustomize/kustomization-details-v1beta1.tsx
@@ -2,7 +2,7 @@ import { Common, Renderer } from "@freelensapp/extensions";
 import crypto from "crypto";
 import { Base64 } from "js-base64";
 import yaml from "js-yaml";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { useEffect, useState } from "react";
 import { Kustomization, type KustomizationStore } from "../../../k8s/fluxcd/kustomize/kustomization-v1beta1";
 import { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
@@ -14,6 +14,8 @@ import { getConditionClass, getConditionText, getStatusMessage } from "../../sta
 import { StatusInventory } from "../../status-inventory";
 import styles from "./kustomization-details.module.scss";
 import stylesInline from "./kustomization-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/kustomize/kustomization-details-v1beta2.tsx
+++ b/src/renderer/components/details/kustomize/kustomization-details-v1beta2.tsx
@@ -2,7 +2,7 @@ import { Common, Renderer } from "@freelensapp/extensions";
 import crypto from "crypto";
 import { Base64 } from "js-base64";
 import yaml from "js-yaml";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { useEffect, useState } from "react";
 import { Kustomization, type KustomizationStore } from "../../../k8s/fluxcd/kustomize/kustomization-v1beta2";
 import { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
@@ -14,6 +14,8 @@ import { getConditionClass, getConditionText, getStatusMessage } from "../../sta
 import { StatusInventory } from "../../status-inventory";
 import styles from "./kustomization-details.module.scss";
 import stylesInline from "./kustomization-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/notification/alert-details-v1beta1.tsx
+++ b/src/renderer/components/details/notification/alert-details-v1beta1.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Alert } from "../../../k8s/fluxcd/notification/alert-v1beta1";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, DrawerItem, LinkToObject },

--- a/src/renderer/components/details/notification/alert-details-v1beta2.tsx
+++ b/src/renderer/components/details/notification/alert-details-v1beta2.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Alert } from "../../../k8s/fluxcd/notification/alert-v1beta2";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, DrawerItem, DrawerItemLabels, LinkToObject },

--- a/src/renderer/components/details/notification/alert-details-v1beta3.tsx
+++ b/src/renderer/components/details/notification/alert-details-v1beta3.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Alert } from "../../../k8s/fluxcd/notification/alert-v1beta3";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, DrawerItem, DrawerItemLabels, LinkToObject },

--- a/src/renderer/components/details/notification/provider-details-v1beta1.tsx
+++ b/src/renderer/components/details/notification/provider-details-v1beta1.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Provider } from "../../../k8s/fluxcd/notification/provider-v1beta1";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/notification/provider-details-v1beta2.tsx
+++ b/src/renderer/components/details/notification/provider-details-v1beta2.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Provider } from "../../../k8s/fluxcd/notification/provider-v1beta2";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/notification/provider-details-v1beta3.tsx
+++ b/src/renderer/components/details/notification/provider-details-v1beta3.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Provider } from "../../../k8s/fluxcd/notification/provider-v1beta3";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/notification/receiver-details-v1.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1.tsx
@@ -7,9 +7,9 @@ import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/notification/receiver-details-v1.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1.tsx
@@ -1,11 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Receiver } from "../../../k8s/fluxcd/notification/receiver-v1";
 import { createEnumFromKeys } from "../../../utils";
 import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
 

--- a/src/renderer/components/details/notification/receiver-details-v1beta1.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1beta1.tsx
@@ -1,11 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Receiver } from "../../../k8s/fluxcd/notification/receiver-v1beta1";
 import { createEnumFromKeys } from "../../../utils";
 import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
 

--- a/src/renderer/components/details/notification/receiver-details-v1beta1.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1beta1.tsx
@@ -7,9 +7,9 @@ import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/notification/receiver-details-v1beta2.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1beta2.tsx
@@ -7,9 +7,9 @@ import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/notification/receiver-details-v1beta2.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1beta2.tsx
@@ -1,11 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Receiver } from "../../../k8s/fluxcd/notification/receiver-v1beta2";
 import { createEnumFromKeys } from "../../../utils";
 import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
 

--- a/src/renderer/components/details/notification/receiver-details-v1beta3.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1beta3.tsx
@@ -7,9 +7,9 @@ import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/components/details/notification/receiver-details-v1beta3.tsx
+++ b/src/renderer/components/details/notification/receiver-details-v1beta3.tsx
@@ -1,11 +1,13 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Receiver } from "../../../k8s/fluxcd/notification/receiver-v1beta3";
 import { createEnumFromKeys } from "../../../utils";
 import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import styles from "./receiver-details.module.scss";
 import stylesInline from "./receiver-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
 

--- a/src/renderer/components/details/source/bucket-details-v1.tsx
+++ b/src/renderer/components/details/source/bucket-details-v1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Bucket } from "../../../k8s/fluxcd/source/bucket-v1";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/source/bucket-details-v1beta1.tsx
+++ b/src/renderer/components/details/source/bucket-details-v1beta1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Bucket } from "../../../k8s/fluxcd/source/bucket-v1beta1";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/source/bucket-details-v1beta2.tsx
+++ b/src/renderer/components/details/source/bucket-details-v1beta2.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { Bucket } from "../../../k8s/fluxcd/source/bucket-v1beta2";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/source/git-repository-details-v1.tsx
+++ b/src/renderer/components/details/source/git-repository-details-v1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { GitRepository } from "../../../k8s/fluxcd/source/gitrepository-v1";
 import { getHeight } from "../../../utils";
@@ -7,6 +7,8 @@ import { SpecAccessFrom } from "../../spec-access-from";
 import { StatusArtifact } from "../../status-artifact";
 import styles from "./git-repository-details.module.scss";
 import stylesInline from "./git-repository-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, Icon, LinkToObject, LinkToSecret, MonacoEditor },

--- a/src/renderer/components/details/source/git-repository-details-v1beta1.tsx
+++ b/src/renderer/components/details/source/git-repository-details-v1beta1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { GitRepository } from "../../../k8s/fluxcd/source/gitrepository-v1beta1";
 import { getHeight } from "../../../utils";
@@ -7,6 +7,8 @@ import { SpecAccessFrom } from "../../spec-access-from";
 import { StatusArtifact } from "../../status-artifact";
 import styles from "./git-repository-details.module.scss";
 import stylesInline from "./git-repository-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, Icon, LinkToObject, LinkToSecret, MonacoEditor },

--- a/src/renderer/components/details/source/git-repository-details-v1beta2.tsx
+++ b/src/renderer/components/details/source/git-repository-details-v1beta2.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { GitRepository } from "../../../k8s/fluxcd/source/gitrepository-v1beta2";
 import { getHeight } from "../../../utils";
@@ -7,6 +7,8 @@ import { SpecAccessFrom } from "../../spec-access-from";
 import { StatusArtifact } from "../../status-artifact";
 import styles from "./git-repository-details.module.scss";
 import stylesInline from "./git-repository-details.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, Icon, LinkToObject, LinkToSecret, MonacoEditor },

--- a/src/renderer/components/details/source/helm-chart-details-v1.tsx
+++ b/src/renderer/components/details/source/helm-chart-details-v1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { HelmChart } from "../../../k8s/fluxcd/source/helmchart-v1";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToObject },

--- a/src/renderer/components/details/source/helm-chart-details-v1beta1.tsx
+++ b/src/renderer/components/details/source/helm-chart-details-v1beta1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { HelmChart } from "../../../k8s/fluxcd/source/helmchart-v1beta1";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToObject },

--- a/src/renderer/components/details/source/helm-chart-details-v1beta2.tsx
+++ b/src/renderer/components/details/source/helm-chart-details-v1beta2.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { HelmChart } from "../../../k8s/fluxcd/source/helmchart-v1beta2";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToObject },

--- a/src/renderer/components/details/source/helm-repository-details-v1.tsx
+++ b/src/renderer/components/details/source/helm-repository-details-v1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { HelmRepository } from "../../../k8s/fluxcd/source/helmrepository-v1";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/source/helm-repository-details-v1beta1.tsx
+++ b/src/renderer/components/details/source/helm-repository-details-v1beta1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { HelmRepository } from "../../../k8s/fluxcd/source/helmrepository-v1beta1";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/source/helm-repository-details-v1beta2.tsx
+++ b/src/renderer/components/details/source/helm-repository-details-v1beta2.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { HelmRepository } from "../../../k8s/fluxcd/source/helmrepository-v1beta2";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, LinkToSecret },

--- a/src/renderer/components/details/source/oci-repository-details-v1.tsx
+++ b/src/renderer/components/details/source/oci-repository-details-v1.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { OCIRepository } from "../../../k8s/fluxcd/source/ocirepository-v1";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, LinkToSecret, LinkToServiceAccount },

--- a/src/renderer/components/details/source/oci-repository-details-v1beta2.tsx
+++ b/src/renderer/components/details/source/oci-repository-details-v1beta2.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import React from "react";
 import { OCIRepository } from "../../../k8s/fluxcd/source/ocirepository-v1beta2";
 import { StatusArtifact } from "../../status-artifact";
+
+const { observer } = MobxReact;
 
 const {
   Component: { BadgeBoolean, DrawerItem, DrawerTitle, LinkToSecret, LinkToServiceAccount },

--- a/src/renderer/components/fluxcd-events.tsx
+++ b/src/renderer/components/fluxcd-events.tsx
@@ -1,9 +1,11 @@
 import { Common, Renderer } from "@freelensapp/extensions";
 import { computed, makeObservable, observable } from "mobx";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import moment from "moment";
 import React from "react";
 import * as ReactRouterDom from "react-router-dom";
+
+const { observer } = MobxReact;
 
 const { Link } = ReactRouterDom;
 

--- a/src/renderer/components/spec-access-from.tsx
+++ b/src/renderer/components/spec-access-from.tsx
@@ -3,9 +3,9 @@ import * as MobxReact from "mobx-react";
 import styles from "./spec-access-from.module.scss";
 import stylesInline from "./spec-access-from.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { AccessFrom } from "../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, DrawerItem },

--- a/src/renderer/components/spec-access-from.tsx
+++ b/src/renderer/components/spec-access-from.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import styles from "./spec-access-from.module.scss";
 import stylesInline from "./spec-access-from.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { AccessFrom } from "../k8s/fluxcd/types";
 

--- a/src/renderer/components/spec-patches.tsx
+++ b/src/renderer/components/spec-patches.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { checksum } from "../utils";
 import styles from "./spec-patches.module.scss";
 import stylesInline from "./spec-patches.module.scss?inline";
 import { YamlDump } from "./yaml-dump";
+
+const { observer } = MobxReact;
 
 import type { Patch } from "../k8s/core/types";
 

--- a/src/renderer/components/spec-patches.tsx
+++ b/src/renderer/components/spec-patches.tsx
@@ -5,9 +5,9 @@ import styles from "./spec-patches.module.scss";
 import stylesInline from "./spec-patches.module.scss?inline";
 import { YamlDump } from "./yaml-dump";
 
-const { observer } = MobxReact;
-
 import type { Patch } from "../k8s/core/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: { DrawerItem, DrawerTitle, Icon },

--- a/src/renderer/components/status-artifact.tsx
+++ b/src/renderer/components/status-artifact.tsx
@@ -4,9 +4,9 @@ import { HumanizeBytes } from "./humanizeBytes";
 import styles from "./status-artifact.module.scss";
 import stylesInline from "./status-artifact.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { Artifact } from "../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: { DrawerTitle, DrawerItem, DurationAbsoluteTimestamp },

--- a/src/renderer/components/status-artifact.tsx
+++ b/src/renderer/components/status-artifact.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { HumanizeBytes } from "./humanizeBytes";
 import styles from "./status-artifact.module.scss";
 import stylesInline from "./status-artifact.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { Artifact } from "../k8s/fluxcd/types";
 

--- a/src/renderer/components/status-history.tsx
+++ b/src/renderer/components/status-history.tsx
@@ -1,8 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { checksum } from "../utils";
 import styles from "./status-history.module.scss";
 import stylesInline from "./status-history.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { History } from "../k8s/fluxcd/types";
 

--- a/src/renderer/components/status-history.tsx
+++ b/src/renderer/components/status-history.tsx
@@ -4,9 +4,9 @@ import { checksum } from "../utils";
 import styles from "./status-history.module.scss";
 import stylesInline from "./status-history.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { History } from "../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: { DrawerItem, DrawerItemLabels, DrawerTitle, DurationAbsoluteTimestamp, Icon },

--- a/src/renderer/components/status-inventory.tsx
+++ b/src/renderer/components/status-inventory.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { createEnumFromKeys } from "../utils";
 import { ObjectRefTooltip } from "./object-ref-tooltip";
 import styles from "./status-inventory.module.scss";
 import stylesInline from "./status-inventory.module.scss?inline";
+
+const { observer } = MobxReact;
 
 import type { NamespacedObjectKindReference, ResourceInventory, ResourceRef } from "../k8s/fluxcd/types";
 

--- a/src/renderer/components/status-inventory.tsx
+++ b/src/renderer/components/status-inventory.tsx
@@ -5,9 +5,9 @@ import { ObjectRefTooltip } from "./object-ref-tooltip";
 import styles from "./status-inventory.module.scss";
 import stylesInline from "./status-inventory.module.scss?inline";
 
-const { observer } = MobxReact;
-
 import type { NamespacedObjectKindReference, ResourceInventory, ResourceRef } from "../k8s/fluxcd/types";
+
+const { observer } = MobxReact;
 
 const {
   Component: { DrawerTitle, LinkToNamespace, LinkToObject, Table, TableHead, TableCell, TableRow, WithTooltip },

--- a/src/renderer/components/yaml-dump.tsx
+++ b/src/renderer/components/yaml-dump.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
 import yaml from "js-yaml";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { defaultYamlDumpOptions, getHeight } from "../utils";
 import styles from "./yaml-dump.module.scss";
 import stylesInline from "./yaml-dump.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { MonacoEditor },

--- a/src/renderer/pages/controlplane/fluxinstances-v1.tsx
+++ b/src/renderer/pages/controlplane/fluxinstances-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { FluxInstance, type FluxInstanceApi } from "../../k8s/fluxcd/controlplane/fluxinstance-v1";
 import styles from "./fluxinstances.module.scss";
 import stylesInline from "./fluxinstances.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/controlplane/fluxreports-v1.tsx
+++ b/src/renderer/pages/controlplane/fluxreports-v1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import {
   getConditionClass,
@@ -10,6 +10,8 @@ import {
 import { FluxReport, type FluxReportApi } from "../../k8s/fluxcd/controlplane/fluxreport-v1";
 import styles from "./fluxreports.module.scss";
 import stylesInline from "./fluxreports.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/pages/controlplane/resourcesetinputproviders-v1.tsx
+++ b/src/renderer/pages/controlplane/resourcesetinputproviders-v1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import {
@@ -8,6 +8,8 @@ import {
 } from "../../k8s/fluxcd/controlplane/resourcesetinputprovider-v1";
 import styles from "./resourcesetinputproviders.module.scss";
 import stylesInline from "./resourcesetinputproviders.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/controlplane/resourcesets-v1.tsx
+++ b/src/renderer/pages/controlplane/resourcesets-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ResourceSet, type ResourceSetApi } from "../../k8s/fluxcd/controlplane/resourceset-v1";
 import styles from "./resourcesets.module.scss";
 import stylesInline from "./resourcesets.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/helm/helmreleases-v2.tsx
+++ b/src/renderer/pages/helm/helmreleases-v2.tsx
@@ -1,11 +1,13 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmRelease, type HelmReleaseApi } from "../../k8s/fluxcd/helm/helmrelease-v2";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./helmreleases.module.scss";
 import stylesInline from "./helmreleases.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/helm/helmreleases-v2beta1.tsx
+++ b/src/renderer/pages/helm/helmreleases-v2beta1.tsx
@@ -1,11 +1,13 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmRelease, type HelmReleaseApi } from "../../k8s/fluxcd/helm/helmrelease-v2beta1";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./helmreleases.module.scss";
 import stylesInline from "./helmreleases.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/helm/helmreleases-v2beta2.tsx
+++ b/src/renderer/pages/helm/helmreleases-v2beta2.tsx
@@ -1,11 +1,13 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmRelease, type HelmReleaseApi } from "../../k8s/fluxcd/helm/helmrelease-v2beta2";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./helmreleases.module.scss";
 import stylesInline from "./helmreleases.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/image/imagepolicies-v1.tsx
+++ b/src/renderer/pages/image/imagepolicies-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ImagePolicy, type ImagePolicyApi } from "../../k8s/fluxcd/image/imagepolicy-v1";
 import styles from "./imagepolicies.module.scss";
 import stylesInline from "./imagepolicies.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/image/imagepolicies-v1beta1.tsx
+++ b/src/renderer/pages/image/imagepolicies-v1beta1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ImagePolicy, type ImagePolicyApi } from "../../k8s/fluxcd/image/imagepolicy-v1beta1";
 import styles from "./imagepolicies.module.scss";
 import stylesInline from "./imagepolicies.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/image/imagepolicies-v1beta2.tsx
+++ b/src/renderer/pages/image/imagepolicies-v1beta2.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ImagePolicy, type ImagePolicyApi } from "../../k8s/fluxcd/image/imagepolicy-v1beta2";
 import styles from "./imagepolicies.module.scss";
 import stylesInline from "./imagepolicies.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/image/imagerepositories-v1.tsx
+++ b/src/renderer/pages/image/imagerepositories-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ImageRepository, type ImageRepositoryApi } from "../../k8s/fluxcd/image/imagerepository-v1";
 import styles from "./imagerepositories.module.scss";
 import stylesInline from "./imagerepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/image/imagerepositories-v1beta1.tsx
+++ b/src/renderer/pages/image/imagerepositories-v1beta1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ImageRepository, type ImageRepositoryApi } from "../../k8s/fluxcd/image/imagerepository-v1beta1";
 import styles from "./imagerepositories.module.scss";
 import stylesInline from "./imagerepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/image/imagerepositories-v1beta2.tsx
+++ b/src/renderer/pages/image/imagerepositories-v1beta2.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ImageRepository, type ImageRepositoryApi } from "../../k8s/fluxcd/image/imagerepository-v1beta2";
 import styles from "./imagerepositories.module.scss";
 import stylesInline from "./imagerepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/image/imageupdateautomations-v1.tsx
+++ b/src/renderer/pages/image/imageupdateautomations-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { ImageUpdateAutomation, type ImageUpdateAutomationApi } from "../../k8s/fluxcd/image/imageupdateautomation-v1";
 import styles from "./imageupdateautomations.module.scss";
 import stylesInline from "./imageupdateautomations.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/pages/image/imageupdateautomations-v1beta1.tsx
+++ b/src/renderer/pages/image/imageupdateautomations-v1beta1.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import {
@@ -8,6 +8,8 @@ import {
 } from "../../k8s/fluxcd/image/imageupdateautomation-v1beta1";
 import styles from "./imageupdateautomations.module.scss";
 import stylesInline from "./imageupdateautomations.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/pages/image/imageupdateautomations-v1beta2.tsx
+++ b/src/renderer/pages/image/imageupdateautomations-v1beta2.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import {
@@ -8,6 +8,8 @@ import {
 } from "../../k8s/fluxcd/image/imageupdateautomation-v1beta2";
 import styles from "./imageupdateautomations.module.scss";
 import stylesInline from "./imageupdateautomations.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: {

--- a/src/renderer/pages/kustomize/kustomizations-v1.tsx
+++ b/src/renderer/pages/kustomize/kustomizations-v1.tsx
@@ -1,11 +1,13 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { Kustomization, type KustomizationApi } from "../../k8s/fluxcd/kustomize/kustomization-v1";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./kustomizations.module.scss";
 import stylesInline from "./kustomizations.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/kustomize/kustomizations-v1beta1.tsx
+++ b/src/renderer/pages/kustomize/kustomizations-v1beta1.tsx
@@ -1,11 +1,13 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { Kustomization, type KustomizationApi } from "../../k8s/fluxcd/kustomize/kustomization-v1beta1";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./kustomizations.module.scss";
 import stylesInline from "./kustomizations.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/kustomize/kustomizations-v1beta2.tsx
+++ b/src/renderer/pages/kustomize/kustomizations-v1beta2.tsx
@@ -1,11 +1,13 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { Kustomization, type KustomizationApi } from "../../k8s/fluxcd/kustomize/kustomization-v1beta2";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./kustomizations.module.scss";
 import stylesInline from "./kustomizations.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/notifications/alerts-v1beta1.tsx
+++ b/src/renderer/pages/notifications/alerts-v1beta1.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Alert, type AlertApi } from "../../k8s/fluxcd/notification/alert-v1beta1";
 import styles from "./alerts.module.scss";
 import stylesInline from "./alerts.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/alerts-v1beta2.tsx
+++ b/src/renderer/pages/notifications/alerts-v1beta2.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Alert, type AlertApi } from "../../k8s/fluxcd/notification/alert-v1beta2";
 import styles from "./alerts.module.scss";
 import stylesInline from "./alerts.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/alerts-v1beta3.tsx
+++ b/src/renderer/pages/notifications/alerts-v1beta3.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Alert, type AlertApi } from "../../k8s/fluxcd/notification/alert-v1beta3";
 import styles from "./alerts.module.scss";
 import stylesInline from "./alerts.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/providers-v1beta1.tsx
+++ b/src/renderer/pages/notifications/providers-v1beta1.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Provider, type ProviderApi } from "../../k8s/fluxcd/notification/provider-v1beta1";
 import styles from "./providers.module.scss";
 import stylesInline from "./providers.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/providers-v1beta2.tsx
+++ b/src/renderer/pages/notifications/providers-v1beta2.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Provider, type ProviderApi } from "../../k8s/fluxcd/notification/provider-v1beta2";
 import styles from "./providers.module.scss";
 import stylesInline from "./providers.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/providers-v1beta3.tsx
+++ b/src/renderer/pages/notifications/providers-v1beta3.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Provider, type ProviderApi } from "../../k8s/fluxcd/notification/provider-v1beta3";
 import styles from "./providers.module.scss";
 import stylesInline from "./providers.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/receivers-v1.tsx
+++ b/src/renderer/pages/notifications/receivers-v1.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Receiver, type ReceiverApi } from "../../k8s/fluxcd/notification/receiver-v1";
 import styles from "./receivers.module.scss";
 import stylesInline from "./receivers.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/receivers-v1beta1.tsx
+++ b/src/renderer/pages/notifications/receivers-v1beta1.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Receiver, type ReceiverApi } from "../../k8s/fluxcd/notification/receiver-v1beta1";
 import styles from "./receivers.module.scss";
 import stylesInline from "./receivers.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/receivers-v1beta2.tsx
+++ b/src/renderer/pages/notifications/receivers-v1beta2.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Receiver, type ReceiverApi } from "../../k8s/fluxcd/notification/receiver-v1beta2";
 import styles from "./receivers.module.scss";
 import stylesInline from "./receivers.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/notifications/receivers-v1beta3.tsx
+++ b/src/renderer/pages/notifications/receivers-v1beta3.tsx
@@ -1,9 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { Receiver, type ReceiverApi } from "../../k8s/fluxcd/notification/receiver-v1beta3";
 import styles from "./receivers.module.scss";
 import stylesInline from "./receivers.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/overview.tsx
+++ b/src/renderer/pages/overview.tsx
@@ -1,5 +1,5 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FluxCDEvents } from "../components/fluxcd-events";
 import { InfoPage } from "../components/info-page";
@@ -47,6 +47,8 @@ import { OCIRepository as OCIRepository_v1 } from "../k8s/fluxcd/source/ocirepos
 import { OCIRepository as OCIRepository_v1beta2 } from "../k8s/fluxcd/source/ocirepository-v1beta2";
 import styles from "./overview.module.scss";
 import stylesInline from "./overview.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { NamespaceSelectFilter, TabLayout },

--- a/src/renderer/pages/source/buckets-v1.tsx
+++ b/src/renderer/pages/source/buckets-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { Bucket, type BucketApi } from "../../k8s/fluxcd/source/bucket-v1";
 import styles from "./buckets.module.scss";
 import stylesInline from "./buckets.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/buckets-v1beta1.tsx
+++ b/src/renderer/pages/source/buckets-v1beta1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { Bucket, type BucketApi } from "../../k8s/fluxcd/source/bucket-v1beta1";
 import styles from "./buckets.module.scss";
 import stylesInline from "./buckets.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/buckets-v1beta2.tsx
+++ b/src/renderer/pages/source/buckets-v1beta2.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { Bucket, type BucketApi } from "../../k8s/fluxcd/source/bucket-v1beta2";
 import styles from "./buckets.module.scss";
 import stylesInline from "./buckets.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/gitrepositories-v1.tsx
+++ b/src/renderer/pages/source/gitrepositories-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { GitRepository, type GitRepositoryApi } from "../../k8s/fluxcd/source/gitrepository-v1";
 import styles from "./gitrepositories.module.scss";
 import stylesInline from "./gitrepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/gitrepositories-v1beta1.tsx
+++ b/src/renderer/pages/source/gitrepositories-v1beta1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { GitRepository, type GitRepositoryApi } from "../../k8s/fluxcd/source/gitrepository-v1beta1";
 import styles from "./gitrepositories.module.scss";
 import stylesInline from "./gitrepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/gitrepositories-v1beta2.tsx
+++ b/src/renderer/pages/source/gitrepositories-v1beta2.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { GitRepository, type GitRepositoryApi } from "../../k8s/fluxcd/source/gitrepository-v1beta2";
 import styles from "./gitrepositories.module.scss";
 import stylesInline from "./gitrepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/helmcharts-v1.tsx
+++ b/src/renderer/pages/source/helmcharts-v1.tsx
@@ -1,5 +1,5 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmChart, type HelmChartApi } from "../../k8s/fluxcd/source/helmchart-v1";
@@ -7,6 +7,8 @@ import { getRefUrl } from "../../k8s/fluxcd/utils";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./helmcharts.module.scss";
 import stylesInline from "./helmcharts.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/source/helmcharts-v1beta1.tsx
+++ b/src/renderer/pages/source/helmcharts-v1beta1.tsx
@@ -1,5 +1,5 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmChart, type HelmChartApi } from "../../k8s/fluxcd/source/helmchart-v1beta1";
@@ -7,6 +7,8 @@ import { getRefUrl } from "../../k8s/fluxcd/utils";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./helmcharts.module.scss";
 import stylesInline from "./helmcharts.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/source/helmcharts-v1beta2.tsx
+++ b/src/renderer/pages/source/helmcharts-v1beta2.tsx
@@ -1,5 +1,5 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmChart, type HelmChartApi } from "../../k8s/fluxcd/source/helmchart-v1beta2";
@@ -7,6 +7,8 @@ import { getRefUrl } from "../../k8s/fluxcd/utils";
 import { getMaybeDetailsUrl } from "../../utils";
 import styles from "./helmcharts.module.scss";
 import stylesInline from "./helmcharts.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Util: { stopPropagation },

--- a/src/renderer/pages/source/helmrepositories-v1.tsx
+++ b/src/renderer/pages/source/helmrepositories-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmRepository, type HelmRepositoryApi } from "../../k8s/fluxcd/source/helmrepository-v1";
 import styles from "./helmrepositories.module.scss";
 import stylesInline from "./helmrepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/helmrepositories-v1beta1.tsx
+++ b/src/renderer/pages/source/helmrepositories-v1beta1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmRepository, type HelmRepositoryApi } from "../../k8s/fluxcd/source/helmrepository-v1beta1";
 import styles from "./helmrepositories.module.scss";
 import stylesInline from "./helmrepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/helmrepositories-v1beta2.tsx
+++ b/src/renderer/pages/source/helmrepositories-v1beta2.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { HelmRepository, type HelmRepositoryApi } from "../../k8s/fluxcd/source/helmrepository-v1beta2";
 import styles from "./helmrepositories.module.scss";
 import stylesInline from "./helmrepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/ocirepositories-v1.tsx
+++ b/src/renderer/pages/source/ocirepositories-v1.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { OCIRepository, type OCIRepositoryApi } from "../../k8s/fluxcd/source/ocirepository-v1";
 import styles from "./ocirepositories.module.scss";
 import stylesInline from "./ocirepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },

--- a/src/renderer/pages/source/ocirepositories-v1beta2.tsx
+++ b/src/renderer/pages/source/ocirepositories-v1beta2.tsx
@@ -1,10 +1,12 @@
 import { Renderer } from "@freelensapp/extensions";
-import { observer } from "mobx-react";
+import * as MobxReact from "mobx-react";
 import { withErrorPage } from "../../components/error-page";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../components/status-conditions";
 import { OCIRepository, type OCIRepositoryApi } from "../../k8s/fluxcd/source/ocirepository-v1beta2";
 import styles from "./ocirepositories.module.scss";
 import stylesInline from "./ocirepositories.module.scss?inline";
+
+const { observer } = MobxReact;
 
 const {
   Component: { Badge, BadgeBoolean, KubeObjectAge, KubeObjectListLayout, NamespaceSelectBadge, WithTooltip },


### PR DESCRIPTION
The workaround is to `import * as` then unpack the symbols.