### PR TITLE
Add FluxInstance distribution variant field and detail view

### DIFF
--- a/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
@@ -109,6 +109,9 @@ export const FluxInstanceDetails: React.FC<Renderer.Component.KubeObjectDetailsP
         <DrawerTitle>Distribution</DrawerTitle>
         <DrawerItem name="Version">{object.spec.distribution.version}</DrawerItem>
         <DrawerItem name="Registry">{object.spec.distribution.registry}</DrawerItem>
+        <DrawerItem name="Variant" hidden={!object.spec.distribution.variant}>
+          {object.spec.distribution.variant}
+        </DrawerItem>
         <DrawerItem name="Image Pull Secret" hidden={!object.spec.distribution.imagePullSecret}>
           <LinkToSecret name={object.spec.distribution.imagePullSecret} namespace={namespace} />
         </DrawerItem>

--- a/src/renderer/k8s/fluxcd/controlplane/fluxinstance-v1.ts
+++ b/src/renderer/k8s/fluxcd/controlplane/fluxinstance-v1.ts
@@ -8,6 +8,7 @@ import type { History, ResourceInventory } from "../types";
 export interface Distribution {
   version: string;
   registry: string;
+  variant?: "upstream-alpine" | "enterprise-alpine" | "enterprise-distroless" | "enterprise-distroless-fips";
   imagePullSecret?: string;
   artifact?: string;
   artifactPullSecret?: string;


### PR DESCRIPTION
Implements the `spec -> distribution -> variant` field for the `fluxcd.controlplane.io/v1` FluxInstance (API model + detail view).

Refs #256

## Reference

The `variant` field originates from the flux-operator API in the `controlplaneio-fluxcd/flux-operator` repository:

- [`api/v1/fluxinstance_types.go`](https://github.com/controlplaneio-fluxcd/flux-operator/blob/main/api/v1/fluxinstance_types.go) — the `Distribution` struct:

```go
// Variant specifies the Flux distribution flavor stored
// in the registry.
// +kubebuilder:validation:Enum=upstream-alpine;enterprise-alpine;enterprise-distroless;enterprise-distroless-fips
// +optional
Variant string `json:"variant,omitempty"`
```

The four enum values (`upstream-alpine`, `enterprise-alpine`, `enterprise-distroless`, `enterprise-distroless-fips`) match the `Variant` union type added in this PR.