### PR TITLE
Add spec.provider field to GitRepository, HelmRepository, and ImageRepository

### DIFF
--- a/src/renderer/components/details/image/image-repository-details-v1.tsx
+++ b/src/renderer/components/details/image/image-repository-details-v1.tsx
@@ -31,6 +31,7 @@ export const ImageRepositoryDetails: React.FC<Renderer.Component.KubeObjectDetai
               </DrawerItem>
             ))}
           </DrawerItem>
+          <DrawerItem name="Authentication Provider">{object.spec.provider ?? "generic"}</DrawerItem>
           <DrawerItem name="Image Registry Credentials" hidden={!object.spec.secretRef}>
             <LinkToSecret name={object.spec.secretRef?.name} namespace={namespace} />
           </DrawerItem>

--- a/src/renderer/components/details/source/git-repository-details-v1.tsx
+++ b/src/renderer/components/details/source/git-repository-details-v1.tsx
@@ -37,6 +37,7 @@ export const GitRepositoryDetails: React.FC<Renderer.Component.KubeObjectDetails
           <DrawerItem name="Revision" hidden={!gitRevision}>
             {gitRevision}
           </DrawerItem>
+          <DrawerItem name="Authentication Provider">{object.spec.provider ?? "generic"}</DrawerItem>
           <DrawerItem name="Git Credentials" hidden={!object.spec.secretRef}>
             <LinkToSecret name={object.spec.secretRef?.name} namespace={namespace} />
           </DrawerItem>

--- a/src/renderer/components/details/source/helm-repository-details-v1.tsx
+++ b/src/renderer/components/details/source/helm-repository-details-v1.tsx
@@ -22,6 +22,9 @@ export const HelmRepositoryDetails: React.FC<Renderer.Component.KubeObjectDetail
         </DrawerItem>
         <DrawerItem name="Interval">{object.spec.interval}</DrawerItem>
         <DrawerItem name="Timeout">{object.spec.timeout ?? "60s"}</DrawerItem>
+        <DrawerItem name="Authentication Provider" hidden={object.spec.type !== "oci" && !object.spec.provider}>
+          {object.spec.provider ?? "generic"}
+        </DrawerItem>
         <DrawerItem name="Authentication Credentials" hidden={!object.spec.secretRef}>
           <LinkToSecret name={object.spec.secretRef?.name} namespace={namespace} />
         </DrawerItem>

--- a/src/renderer/k8s/fluxcd/image/imagerepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/image/imagerepository-v1.ts
@@ -15,9 +15,6 @@ export interface ImageRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
   interval: string;
   timeout?: string;
   secretRef?: LocalObjectReference;
-  // Provider used for authentication, defaults to "generic".
-  // Upstream: fluxcd/image-reflector-controller api/v1/imagerepository_types.go, ImageRepositorySpec.Provider
-  // +kubebuilder:validation:Enum=generic;aws;azure;gcp
   provider?: "generic" | "aws" | "azure" | "gcp";
   serviceAccountName?: string;
   certSecretRef?: LocalObjectReference;

--- a/src/renderer/k8s/fluxcd/image/imagerepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/image/imagerepository-v1.ts
@@ -15,6 +15,10 @@ export interface ImageRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
   interval: string;
   timeout?: string;
   secretRef?: LocalObjectReference;
+  // Provider used for authentication, defaults to "generic".
+  // Upstream: fluxcd/image-reflector-controller api/v1/imagerepository_types.go, ImageRepositorySpec.Provider
+  // +kubebuilder:validation:Enum=generic;aws;azure;gcp
+  provider?: "generic" | "aws" | "azure" | "gcp";
   serviceAccountName?: string;
   certSecretRef?: LocalObjectReference;
   suspend?: boolean;

--- a/src/renderer/k8s/fluxcd/source/gitrepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/source/gitrepository-v1.ts
@@ -21,9 +21,6 @@ export interface GitRepositoryInclude {
 export interface GitRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
   url: string;
   secretRef?: LocalObjectReference;
-  // Provider used for authentication, defaults to "generic".
-  // Upstream: fluxcd/source-controller api/v1/gitrepository_types.go, GitRepositorySpec.Provider
-  // +kubebuilder:validation:Enum=generic;aws;azure;github
   provider?: "generic" | "aws" | "azure" | "github";
   interval: string;
   timeout?: string;

--- a/src/renderer/k8s/fluxcd/source/gitrepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/source/gitrepository-v1.ts
@@ -21,6 +21,10 @@ export interface GitRepositoryInclude {
 export interface GitRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
   url: string;
   secretRef?: LocalObjectReference;
+  // Provider used for authentication, defaults to "generic".
+  // Upstream: fluxcd/source-controller api/v1/gitrepository_types.go, GitRepositorySpec.Provider
+  // +kubebuilder:validation:Enum=generic;aws;azure;github
+  provider?: "generic" | "aws" | "azure" | "github";
   interval: string;
   timeout?: string;
   ref?: GitRepositoryRef;

--- a/src/renderer/k8s/fluxcd/source/helmrepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/source/helmrepository-v1.ts
@@ -28,6 +28,10 @@ export interface HelmRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
   accessFrom?: AccessFrom;
   // source.toolkit.fluxcd.io/v1
   type?: "helm" | "oci";
+  // Provider used for authentication, only taken into account when type is "oci", defaults to "generic".
+  // Upstream: fluxcd/source-controller api/v1/helmrepository_types.go, HelmRepositorySpec.Provider
+  // +kubebuilder:validation:Enum=generic;aws;azure;gcp
+  provider?: "generic" | "aws" | "azure" | "gcp";
 }
 
 export interface HelmRepositoryStatus extends FluxCDKubeObjectStatus {

--- a/src/renderer/k8s/fluxcd/source/helmrepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/source/helmrepository-v1.ts
@@ -28,9 +28,6 @@ export interface HelmRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
   accessFrom?: AccessFrom;
   // source.toolkit.fluxcd.io/v1
   type?: "helm" | "oci";
-  // Provider used for authentication, only taken into account when type is "oci", defaults to "generic".
-  // Upstream: fluxcd/source-controller api/v1/helmrepository_types.go, HelmRepositorySpec.Provider
-  // +kubebuilder:validation:Enum=generic;aws;azure;gcp
   provider?: "generic" | "aws" | "azure" | "gcp";
 }
 


### PR DESCRIPTION
Adds the authentication `spec.provider` field to the newest served API versions of GitRepository and HelmRepository (source.toolkit.fluxcd.io/v1) and ImageRepository (image.toolkit.fluxcd.io/v1), and renders it in their detail views as "Authentication Provider".

Refs #256
