### PR TITLE
Remove stale fields from the newest FluxCD API versions

### DIFF
--- a/src/renderer/components/details/kustomize/kustomization-details-v1.tsx
+++ b/src/renderer/components/details/kustomize/kustomization-details-v1.tsx
@@ -1,5 +1,4 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import crypto from "crypto";
 import { Base64 } from "js-base64";
 import { dump } from "js-yaml";
 import * as MobxReact from "mobx-react";
@@ -184,97 +183,6 @@ export const KustomizationDetails: React.FC<Renderer.Component.KubeObjectDetails
           )}
 
           <SpecPatches patches={object.spec.patches} />
-
-          {object.spec.patchesStrategicMerge && (
-            <div>
-              <DrawerTitle>Patches: Strategic Merge</DrawerTitle>
-              {object.spec.patchesStrategicMerge.map((patch) => {
-                const key = crypto.createHash("sha256").update(JSON.stringify(patch)).digest("hex").substring(0, 16);
-
-                return (
-                  <div key={key}>
-                    <div className={styles.title}>
-                      <Icon small material="list" />
-                    </div>
-                    <MonacoEditor
-                      readOnly
-                      style={{
-                        minHeight: getHeight(patch),
-                        resize: "none",
-                        overflow: "hidden",
-                        border: "1px solid var(--borderFaintColor)",
-                        borderRadius: "4px",
-                      }}
-                      value={patch}
-                      setInitialHeight
-                      options={{
-                        scrollbar: {
-                          alwaysConsumeMouseWheel: false,
-                        },
-                      }}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {object.spec.patchesJson6902 && (
-            <div>
-              <DrawerTitle>Patches: RFC 6902</DrawerTitle>
-              {object.spec.patchesJson6902.map((patch) => {
-                const patchYaml = dump(patch.patch, defaultYamlDumpOptions);
-                const key = crypto.createHash("sha256").update(JSON.stringify(patch)).digest("hex").substring(0, 16);
-
-                return (
-                  <div key={key}>
-                    <div className={styles.title}>
-                      <Icon small material="list" />
-                    </div>
-                    <DrawerItem name="Group" hidden={!patch.target?.group}>
-                      {patch.target?.group}
-                    </DrawerItem>
-                    <DrawerItem name="Version" hidden={!patch.target?.version}>
-                      {patch.target?.version}
-                    </DrawerItem>
-                    <DrawerItem name="Kind" hidden={!patch.target?.kind}>
-                      {patch.target?.kind}
-                    </DrawerItem>
-                    <DrawerItem name="Name" hidden={!patch.target?.name}>
-                      {patch.target?.name}
-                    </DrawerItem>
-                    <DrawerItem name="Namespace" hidden={!patch.target?.namespace}>
-                      {patch.target?.namespace}
-                    </DrawerItem>
-                    <DrawerItem name="Label Selector" hidden={!patch.target?.labelSelector}>
-                      {patch.target?.labelSelector}
-                    </DrawerItem>
-                    <DrawerItem name="Annotation Selector" hidden={!patch.target?.annotationSelector}>
-                      {patch.target?.annotationSelector}
-                    </DrawerItem>
-                    <div className="DrawerItem">Patch</div>
-                    <MonacoEditor
-                      readOnly
-                      style={{
-                        minHeight: getHeight(patchYaml),
-                        resize: "none",
-                        overflow: "hidden",
-                        border: "1px solid var(--borderFaintColor)",
-                        borderRadius: "4px",
-                      }}
-                      value={patchYaml}
-                      setInitialHeight
-                      options={{
-                        scrollbar: {
-                          alwaysConsumeMouseWheel: false,
-                        },
-                      }}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          )}
 
           {object.spec.images && (
             <div>

--- a/src/renderer/components/details/source/git-repository-details-v1.tsx
+++ b/src/renderer/components/details/source/git-repository-details-v1.tsx
@@ -3,7 +3,6 @@ import * as MobxReact from "mobx-react";
 import React from "react";
 import { GitRepository } from "../../../k8s/fluxcd/source/gitrepository-v1";
 import { getHeight } from "../../../utils";
-import { SpecAccessFrom } from "../../spec-access-from";
 import { StatusArtifact } from "../../status-artifact";
 import styles from "./git-repository-details.module.scss";
 import stylesInline from "./git-repository-details.module.scss?inline";
@@ -63,11 +62,7 @@ export const GitRepositoryDetails: React.FC<Renderer.Component.KubeObjectDetails
               }}
             />
           </DrawerItem>
-          <DrawerItem name="Git Implementation">{object.spec.gitImplementation ?? "go-git"}</DrawerItem>
-          <DrawerItem
-            name="Recurse Submodules"
-            hidden={object.spec.gitImplementation && object.spec.gitImplementation !== "go-git"}
-          >
+          <DrawerItem name="Recurse Submodules">
             <BadgeBoolean value={object.spec.recurseSubmodules ?? false} />
           </DrawerItem>
 
@@ -91,8 +86,6 @@ export const GitRepositoryDetails: React.FC<Renderer.Component.KubeObjectDetails
               })}
             </div>
           )}
-
-          <SpecAccessFrom accessFrom={object.spec.accessFrom} />
 
           <StatusArtifact artifact={object.status?.artifact} />
         </div>

--- a/src/renderer/components/details/source/helm-chart-details-v1.tsx
+++ b/src/renderer/components/details/source/helm-chart-details-v1.tsx
@@ -29,9 +29,6 @@ export const HelmChartDetails: React.FC<Renderer.Component.KubeObjectDetailsProp
         {object.spec.valuesFiles?.length &&
           object.spec.valuesFiles.map((file) => <DrawerItem name="">{file}</DrawerItem>)}
       </DrawerItem>
-      <DrawerItem name="Values File" hidden={!object.spec.valuesFile}>
-        <DrawerItem name="">{object.spec.valuesFile}</DrawerItem>
-      </DrawerItem>
 
       <StatusArtifact artifact={object.status?.artifact} />
     </div>

--- a/src/renderer/k8s/fluxcd/image/imagepolicy-v1.ts
+++ b/src/renderer/k8s/fluxcd/image/imagepolicy-v1.ts
@@ -31,9 +31,7 @@ export interface ImagePolicySpec {
   filterTags?: TagFilter;
 }
 
-export interface ImagePolicyStatus extends FluxCDKubeObjectStatus {
-  latestImage?: string;
-}
+export interface ImagePolicyStatus extends FluxCDKubeObjectStatus {}
 
 export class ImagePolicy extends Renderer.K8sApi.LensExtensionKubeObject<
   Renderer.K8sApi.KubeObjectMetadata,

--- a/src/renderer/k8s/fluxcd/kustomize/kustomization-v1.ts
+++ b/src/renderer/k8s/fluxcd/kustomize/kustomization-v1.ts
@@ -8,12 +8,10 @@ import type {
   FluxCDKubeObjectSpecWithSuspend,
   FluxCDKubeObjectStatus,
   Image,
-  JSON6902Patch,
   KubeConfigReference,
   NamespacedObjectKindReference,
   NamespacedObjectReference,
   ResourceInventory,
-  Snapshot,
 } from "../types";
 
 export interface Decryption {
@@ -42,22 +40,18 @@ export interface KustomizationSpec extends FluxCDKubeObjectSpecWithSuspend {
   prune: boolean;
   healthChecks?: NamespacedObjectKindReference[];
   patches?: Patch[];
-  patchesStrategicMerge?: string[];
-  patchesJson6902: JSON6902Patch[];
   images: Image[];
   serviceAccountName?: string;
   sourceRef: NamespacedObjectKindReference;
   suspend?: boolean;
   targetNamespace?: string;
   timeout?: string;
-  validation?: "client" | "server" | "none";
   force?: boolean;
 }
 
 export interface KustomizationStatus extends FluxCDKubeObjectStatus {
   lastAppliedRevision?: string;
   lastAttemptedRevision?: string;
-  snapshot: Snapshot;
   inventory?: ResourceInventory;
 }
 

--- a/src/renderer/k8s/fluxcd/notification/receiver-v1.ts
+++ b/src/renderer/k8s/fluxcd/notification/receiver-v1.ts
@@ -23,9 +23,7 @@ export interface ReceiverSpec extends FluxCDKubeObjectSpecWithSuspend {
   suspend?: boolean;
 }
 
-export interface ReceiverStatus extends FluxCDKubeObjectStatus {
-  url?: string;
-}
+export interface ReceiverStatus extends FluxCDKubeObjectStatus {}
 
 export class Receiver extends Renderer.K8sApi.LensExtensionKubeObject<
   Renderer.K8sApi.KubeObjectMetadata,

--- a/src/renderer/k8s/fluxcd/source/gitrepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/source/gitrepository-v1.ts
@@ -2,7 +2,7 @@ import { Renderer } from "@freelensapp/extensions";
 
 import type { LocalObjectReference } from "@freelensapp/kube-object";
 
-import type { AccessFrom, Artifact, FluxCDKubeObjectSpecWithSuspend, FluxCDKubeObjectStatus } from "../types";
+import type { Artifact, FluxCDKubeObjectSpecWithSuspend, FluxCDKubeObjectStatus } from "../types";
 
 export interface GitRepositoryRef {
   branch?: string;
@@ -28,14 +28,11 @@ export interface GitRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
   verify?: { mode?: string; secretRef?: LocalObjectReference };
   ignore?: string;
   suspend?: boolean;
-  gitImplementation?: "go-git" | "libgit2";
   recurseSubmodules?: boolean;
   include?: GitRepositoryInclude[];
-  accessFrom?: AccessFrom;
 }
 
 export interface GitRepositoryStatus extends FluxCDKubeObjectStatus {
-  url?: string;
   artifact?: Artifact;
   includedArtifacts?: Artifact[];
 }

--- a/src/renderer/k8s/fluxcd/source/helmchart-v1.ts
+++ b/src/renderer/k8s/fluxcd/source/helmchart-v1.ts
@@ -1,6 +1,6 @@
 import { Renderer } from "@freelensapp/extensions";
 
-import type { AccessFrom, Artifact, FluxCDKubeObjectSpecWithSuspend, FluxCDKubeObjectStatus } from "../types";
+import type { Artifact, FluxCDKubeObjectSpecWithSuspend, FluxCDKubeObjectStatus } from "../types";
 
 export interface LocalHelmChartSourceReference {
   apiVersion?: string;
@@ -15,9 +15,7 @@ export interface HelmChartSpec extends FluxCDKubeObjectSpecWithSuspend {
   interval: string;
   reconcileStrategy?: "ChartVersion" | "Revision";
   valuesFiles?: string[];
-  valuesFile?: string;
   suspend?: boolean;
-  accessFrom?: AccessFrom;
 }
 
 export interface HelmChartStatus extends FluxCDKubeObjectStatus {

--- a/src/renderer/k8s/fluxcd/source/ocirepository-v1.ts
+++ b/src/renderer/k8s/fluxcd/source/ocirepository-v1.ts
@@ -46,7 +46,6 @@ export interface OCIRepositorySpec extends FluxCDKubeObjectSpecWithSuspend {
 export interface OCIRepositoryStatus extends FluxCDKubeObjectStatus {
   url?: string;
   artifact?: Artifact;
-  contentConfigChecksum?: string;
   observedIgnore?: string;
   observedLayerSelector?: OCILayerSelector;
 }

--- a/src/renderer/pages/image/imagepolicies-v1.tsx
+++ b/src/renderer/pages/image/imagepolicies-v1.tsx
@@ -20,7 +20,6 @@ const sortingCallbacks = {
   name: (object: KubeObject) => object.getName(),
   namespace: (object: KubeObject) => object.getNs(),
   repository: (object: KubeObject) => object.spec.imageRepositoryRef.name,
-  latestTag: (object: KubeObject) => object.status?.latestImage?.split(":")[1],
   condition: (object: KubeObject) => getConditionText(object.status?.conditions),
   status: (object: KubeObject) => getConditionText(object.status?.conditions),
   age: (object: KubeObject) => object.getCreationTimestamp(),
@@ -30,7 +29,6 @@ const renderTableHeader: { title: string; sortBy: keyof typeof sortingCallbacks;
   { title: "Name", sortBy: "name" },
   { title: "Namespace", sortBy: "namespace" },
   { title: "Repository", sortBy: "repository", className: styles.repository },
-  { title: "Latest Tag", sortBy: "latestTag", className: styles.latestTag },
   { title: "Condition", sortBy: "condition", className: styles.condition },
   { title: "Status", sortBy: "status", className: styles.status },
   { title: "Age", sortBy: "age", className: styles.age },
@@ -59,7 +57,6 @@ export const ImagePoliciesPage = observer((props: ImagePoliciesPageProps) =>
             <WithTooltip>{object.getName()}</WithTooltip>,
             <NamespaceSelectBadge key="namespace" namespace={object.getNs() ?? ""} />,
             <WithTooltip>{object.spec.imageRepositoryRef.name}</WithTooltip>,
-            <WithTooltip>{object.status?.latestImage?.split(":")[1]}</WithTooltip>,
             <Badge
               className={getConditionClass(object.status?.conditions)}
               label={getConditionText(object.status?.conditions)}


### PR DESCRIPTION
Removes fields that no longer exist in the newest served API version of each resource, leaving older API versions untouched. One commit per resource.

- GitRepository v1: spec.gitImplementation, spec.accessFrom, status.url
- HelmChart v1: spec.valuesFile, spec.accessFrom
- OCIRepository v1: status.contentConfigChecksum
- Kustomization v1: spec.patchesStrategicMerge, spec.patchesJson6902, spec.validation, status.snapshot
- ImagePolicy v1: status.latestImage (list page Latest Tag column removed until status.latestRef is modeled)
- Receiver v1: status.url

Part of #256.
