### PR TITLE
Unify key hashing into a shared createHash helper

### DIFF
--- a/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/flux-instance-details-v1.tsx
@@ -1,7 +1,7 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
 import React from "react";
-import { checksum, createEnumFromKeys } from "../../../utils";
+import { createEnumFromKeys, createHash } from "../../../utils";
 import { SpecPatches } from "../../spec-patches";
 import { StatusHistory } from "../../status-history";
 import { StatusInventory } from "../../status-inventory";
@@ -221,7 +221,7 @@ export const FluxInstanceDetails: React.FC<Renderer.Component.KubeObjectDetailsP
                 <TableCell className="digest">Digest</TableCell>
               </TableHead>
               {object.status.components.map((component) => {
-                const key = checksum(component);
+                const key = createHash(component);
                 return (
                   <TableRow key={key} sortItem={component} nowrap>
                     <TableCell className="name">{component.name}</TableCell>

--- a/src/renderer/components/details/controlplane/flux-report-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/flux-report-details-v1.tsx
@@ -1,7 +1,7 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
 import React from "react";
-import { checksum, createEnumFromKeys } from "../../../utils";
+import { createEnumFromKeys, createHash } from "../../../utils";
 import styles from "./flux-report-details.module.scss";
 import stylesInline from "./flux-report-details.module.scss?inline";
 
@@ -94,7 +94,7 @@ export const FluxReportDetails: React.FC<Renderer.Component.KubeObjectDetailsPro
         <>
           <DrawerTitle>Components</DrawerTitle>
           {object.spec.components.map((component) => {
-            const key = checksum(component);
+            const key = createHash(component);
             return (
               <div key={key}>
                 <div className={styles.title}>
@@ -140,7 +140,7 @@ export const FluxReportDetails: React.FC<Renderer.Component.KubeObjectDetailsPro
               <TableCell className="totalSize">Total Size</TableCell>
             </TableHead>
             {object.spec.reconcilers.map((reconciler) => {
-              const key = checksum(reconciler);
+              const key = createHash(reconciler);
               return (
                 <TableRow key={key} sortItem={reconciler} nowrap>
                   <TableCell className="kind">

--- a/src/renderer/components/details/controlplane/resource-set-details.tsx
+++ b/src/renderer/components/details/controlplane/resource-set-details.tsx
@@ -1,7 +1,7 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
 import React from "react";
-import { checksum } from "../../../utils";
+import { createHash } from "../../../utils";
 import { StatusHistory } from "../../status-history";
 import { StatusInventory } from "../../status-inventory";
 import { YamlDump } from "../../yaml-dump";
@@ -112,7 +112,7 @@ export const ResourceSetDetails: React.FC<Renderer.Component.KubeObjectDetailsPr
           <div>
             <DrawerTitle>Inputs From</DrawerTitle>
             {object.spec.inputsFrom.map((inputsFrom) => (
-              <div key={checksum(inputsFrom)}>
+              <div key={createHash(inputsFrom)}>
                 <div className={styles.title}>
                   <Icon small material="list" />
                 </div>
@@ -129,7 +129,7 @@ export const ResourceSetDetails: React.FC<Renderer.Component.KubeObjectDetailsPr
                   <DrawerItemLabels name="Match Labels" labels={inputsFrom.selector?.matchLabels ?? {}} />
                   <DrawerItem name="Match Expressions" hidden={!inputsFrom.selector?.matchExpressions}>
                     {inputsFrom.selector?.matchExpressions?.map((expr) => (
-                      <div key={checksum(expr)}>
+                      <div key={createHash(expr)}>
                         <DrawerItem name="Key">{expr.key}</DrawerItem>
                         <DrawerItem name="Operator">{expr.operator}</DrawerItem>
                         <DrawerItem name="Values" hidden={!expr.values || expr.values.length === 0}>
@@ -150,7 +150,7 @@ export const ResourceSetDetails: React.FC<Renderer.Component.KubeObjectDetailsPr
           <div className={styles.inputs}>
             <DrawerTitle>Inputs</DrawerTitle>
             {object.spec.inputs.map((input, index) => (
-              <div key={checksum(input)}>
+              <div key={createHash(input)}>
                 <div className={styles.title}>
                   <Icon small material="list" />
                   <span>{index + 1}</span>

--- a/src/renderer/components/details/controlplane/resource-set-input-provider-details-v1.tsx
+++ b/src/renderer/components/details/controlplane/resource-set-input-provider-details-v1.tsx
@@ -1,7 +1,7 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
 import React from "react";
-import { checksum, createEnumFromKeys } from "../../../utils";
+import { createEnumFromKeys, createHash } from "../../../utils";
 import { YamlDump } from "../../yaml-dump";
 import styles from "./resource-set-input-provider-details.module.scss";
 import stylesInline from "./resource-set-input-provider-details.module.scss?inline";
@@ -185,7 +185,7 @@ export const ResourceSetInputProviderDetails: React.FC<
         <div className={styles.exportedInputs}>
           <DrawerTitle>Exported Inputs</DrawerTitle>
           {object.status.exportedInputs.map((input, index) => (
-            <div key={checksum(input)}>
+            <div key={createHash(input)}>
               <div className={styles.title}>
                 <Icon small material="list" />
                 <span>{index + 1}</span>

--- a/src/renderer/components/details/kustomize/kustomization-details-v1beta1.tsx
+++ b/src/renderer/components/details/kustomize/kustomization-details-v1beta1.tsx
@@ -1,5 +1,4 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import crypto from "crypto";
 import { Base64 } from "js-base64";
 import { dump } from "js-yaml";
 import * as MobxReact from "mobx-react";
@@ -7,7 +6,7 @@ import { useEffect, useState } from "react";
 import { Kustomization, type KustomizationStore } from "../../../k8s/fluxcd/kustomize/kustomization-v1beta1";
 import { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
 import { getRefUrl } from "../../../k8s/fluxcd/utils";
-import { createEnumFromKeys, defaultYamlDumpOptions, getHeight, getMaybeDetailsUrl } from "../../../utils";
+import { createEnumFromKeys, createHash, defaultYamlDumpOptions, getHeight, getMaybeDetailsUrl } from "../../../utils";
 import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import { SpecPatches } from "../../spec-patches";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../status-conditions";
@@ -184,7 +183,7 @@ export const KustomizationDetails: React.FC<Renderer.Component.KubeObjectDetails
             <div>
               <DrawerTitle>Patches: Strategic Merge</DrawerTitle>
               {object.spec.patchesStrategicMerge.map((patch) => {
-                const key = crypto.createHash("sha256").update(JSON.stringify(patch)).digest("hex").substring(0, 16);
+                const key = createHash(patch);
 
                 return (
                   <div key={key}>
@@ -219,7 +218,7 @@ export const KustomizationDetails: React.FC<Renderer.Component.KubeObjectDetails
               <DrawerTitle>Patches: RFC 6902</DrawerTitle>
               {object.spec.patchesJson6902.map((patch) => {
                 const patchYaml = dump(patch.patch, defaultYamlDumpOptions);
-                const key = crypto.createHash("sha256").update(JSON.stringify(patch)).digest("hex").substring(0, 16);
+                const key = createHash(patch);
 
                 return (
                   <div key={key}>

--- a/src/renderer/components/details/kustomize/kustomization-details-v1beta2.tsx
+++ b/src/renderer/components/details/kustomize/kustomization-details-v1beta2.tsx
@@ -1,5 +1,4 @@
 import { Common, Renderer } from "@freelensapp/extensions";
-import crypto from "crypto";
 import { Base64 } from "js-base64";
 import { dump } from "js-yaml";
 import * as MobxReact from "mobx-react";
@@ -7,7 +6,7 @@ import { useEffect, useState } from "react";
 import { Kustomization, type KustomizationStore } from "../../../k8s/fluxcd/kustomize/kustomization-v1beta2";
 import { NamespacedObjectKindReference } from "../../../k8s/fluxcd/types";
 import { getRefUrl } from "../../../k8s/fluxcd/utils";
-import { createEnumFromKeys, defaultYamlDumpOptions, getHeight, getMaybeDetailsUrl } from "../../../utils";
+import { createEnumFromKeys, createHash, defaultYamlDumpOptions, getHeight, getMaybeDetailsUrl } from "../../../utils";
 import { ObjectRefTooltip } from "../../object-ref-tooltip";
 import { SpecPatches } from "../../spec-patches";
 import { getConditionClass, getConditionText, getStatusMessage } from "../../status-conditions";
@@ -189,7 +188,7 @@ export const KustomizationDetails: React.FC<Renderer.Component.KubeObjectDetails
             <div>
               <DrawerTitle>Patches: Strategic Merge</DrawerTitle>
               {object.spec.patchesStrategicMerge.map((patch) => {
-                const key = crypto.createHash("sha256").update(JSON.stringify(patch)).digest("hex").substring(0, 16);
+                const key = createHash(patch);
 
                 return (
                   <div key={key}>
@@ -224,7 +223,7 @@ export const KustomizationDetails: React.FC<Renderer.Component.KubeObjectDetails
               <DrawerTitle>Patches: RFC 6902</DrawerTitle>
               {object.spec.patchesJson6902.map((patch) => {
                 const patchYaml = dump(patch.patch, defaultYamlDumpOptions);
-                const key = crypto.createHash("sha256").update(JSON.stringify(patch)).digest("hex").substring(0, 16);
+                const key = createHash(patch);
 
                 return (
                   <div key={key}>

--- a/src/renderer/components/spec-patches.tsx
+++ b/src/renderer/components/spec-patches.tsx
@@ -1,6 +1,6 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
-import { checksum } from "../utils";
+import { createHash } from "../utils";
 import styles from "./spec-patches.module.scss";
 import stylesInline from "./spec-patches.module.scss?inline";
 import { YamlDump } from "./yaml-dump";
@@ -30,7 +30,7 @@ export const SpecPatches: React.FC<SpecPatchesProps> = observer((props) => {
         if (!patch) return null;
 
         return (
-          <div key={checksum(patch)}>
+          <div key={createHash(patch)}>
             <div className={styles.title}>
               <Icon small material="list" /> {index + 1}
             </div>

--- a/src/renderer/components/status-history.tsx
+++ b/src/renderer/components/status-history.tsx
@@ -1,6 +1,6 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
-import { checksum } from "../utils";
+import { createHash } from "../utils";
 import styles from "./status-history.module.scss";
 import stylesInline from "./status-history.module.scss?inline";
 
@@ -27,7 +27,7 @@ export const StatusHistory: React.FC<StatusHistoryProps> = observer((props) => {
       <div className={styles.history}>
         <DrawerTitle>History</DrawerTitle>
         {history.map((snapshot) => (
-          <div key={checksum(snapshot)}>
+          <div key={createHash(snapshot)}>
             <div className={styles.title}>
               <Icon small material="history" />
             </div>

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -7,7 +7,7 @@ const {
   Navigation: { getDetailsUrl },
 } = Renderer;
 
-export function checksum(data: any): string {
+export function createHash(data: unknown): string {
   return crypto.createHash("sha256").update(JSON.stringify(data)).digest("hex").substring(0, 16);
 }
 


### PR DESCRIPTION
Rename the checksum helper to createHash (matching the sibling freelens-gateway-api-extension) and replace the inline crypto.createHash calls used for React key attributes in the Kustomization detail views.

Closes #262
