### PR TITLE
Add vitest unit tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,57 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test-unit:
+    name: unit tests
+
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: Setup pnpm
+        run: corepack enable
+
+      - name: Get pnpm cache directory
+        shell: bash
+        run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
+
+      - name: Use pnpm cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.pnpm_cache_dir }}
+          key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ubuntu-24.04-arm-node-
+
+      - name: Install pnpm dependencies
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm --color=always --stream test:unit

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "knip:check": "pnpm \"/^knip:(development|production)\\$/\"",
     "knip:development": "pnpm knip",
     "knip:production": "pnpm knip --production --strict",
+    "test:unit": "vitest run",
     "type:check": "tsc --noEmit -p tsconfig.json --composite false",
     "prebuild": "pnpm type:check",
     "build": "electron-vite build",
@@ -81,7 +82,8 @@
     "sass": "^1.101.0",
     "typescript": "5.9.3",
     "vite": "^8.1.3",
-    "vite-plugin-sass-dts": "^1.3.37"
+    "vite-plugin-sass-dts": "^1.3.37",
+    "vitest": "^4.1.9"
   },
   "keywords": [
     "extension",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       vite-plugin-sass-dts:
         specifier: ^1.3.37
         version: 1.3.37(postcss@8.5.16)(prettier@3.6.2)(sass-embedded@1.89.2)(vite@8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1))
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@22.16.4)(vite@8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1))
 
 packages:
 
@@ -1222,8 +1225,17 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chart.js@2.9.41':
     resolution: {integrity: sha512-3dvkDvueckY83UyUXtJMalYoH6faOLkWQoaTlJgB4Djde3oORmNP0Jw85HtzTuXyliUHcdp704s0mZFQKio/KQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/history@4.7.11':
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
@@ -1285,6 +1297,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -1331,6 +1372,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1422,6 +1467,10 @@ packages:
 
   caniuse-lite@1.0.30001718:
     resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1644,6 +1693,9 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1676,12 +1728,19 @@ packages:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2308,6 +2367,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2681,6 +2743,9 @@ packages:
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2732,8 +2797,14 @@ packages:
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   static-eval@2.0.2:
     resolution: {integrity: sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -2825,9 +2896,20 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2974,6 +3056,52 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   winston-transport-browserconsole@1.0.5:
     resolution: {integrity: sha512-BFZDvknATAmsqaRY3WatB2S0eEb0ziwqBYIv+H0Fnu9oe7GnPUVQzEJC1frmLdNsfEkfnyR1PCNDBAFtZE3SuQ==}
@@ -4398,9 +4526,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chart.js@2.9.41':
     dependencies:
       moment: 2.30.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/history@4.7.11': {}
 
@@ -4463,6 +4600,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1)
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
@@ -4499,6 +4677,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   async@3.2.6: {}
 
@@ -4573,6 +4753,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001718: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4796,6 +4978,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-module-lexer@2.3.0: {}
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -4872,9 +5056,15 @@ snapshots:
 
   estraverse@4.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   eventemitter3@4.0.7: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5441,6 +5631,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -5818,6 +6010,8 @@ snapshots:
 
   setimmediate@1.0.5: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-swizzle@0.2.2:
@@ -5862,9 +6056,13 @@ snapshots:
 
   stack-trace@0.0.10: {}
 
+  stackback@0.0.2: {}
+
   static-eval@2.0.2:
     dependencies:
       escodegen: 1.14.3
+
+  std-env@4.1.0: {}
 
   stoppable@1.1.0: {}
 
@@ -5981,10 +6179,16 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6083,6 +6287,38 @@ snapshots:
       sass-embedded: 1.89.2
       stylus: 0.62.0
       terser: 5.39.1
+
+  vitest@4.1.9(@types/node@22.16.4)(vite@8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@22.16.4)(esbuild@0.27.2)(less@4.3.0)(sass-embedded@1.89.2)(sass@1.101.0)(stylus@0.62.0)(terser@5.39.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.16.4
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   winston-transport-browserconsole@1.0.5:
     dependencies:

--- a/src/renderer/components/status-conditions.test.ts
+++ b/src/renderer/components/status-conditions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+import {
+  getConditionClass,
+  getConditionText,
+  getLastCondition,
+  getLastUpdated,
+  getStatusMessage,
+  sortConditions,
+} from "./status-conditions";
+
+import type { Condition } from "@freelensapp/kube-object";
+
+function condition(overrides: Partial<Condition> = {}): Condition {
+  return {
+    type: "Ready",
+    status: "True",
+    lastTransitionTime: "2024-01-01T00:00:00Z",
+    ...overrides,
+  } as Condition;
+}
+
+describe("sortConditions", () => {
+  test("sorts the newest transition time first", () => {
+    const older = condition({ type: "Initialized", lastTransitionTime: "2024-01-01T00:00:00Z" });
+    const newer = condition({ type: "Ready", lastTransitionTime: "2024-01-02T00:00:00Z" });
+    expect(sortConditions([older, newer])?.map((c) => c.type)).toEqual(["Ready", "Initialized"]);
+  });
+
+  test("breaks ties on equal timestamps using the default type priority", () => {
+    const time = "2024-01-01T00:00:00Z";
+    const ready = condition({ type: "Ready", lastTransitionTime: time });
+    const synced = condition({ type: "Synced", lastTransitionTime: time });
+    // Ready (5) has a higher priority than Synced (4), so it comes first.
+    expect(sortConditions([synced, ready])?.map((c) => c.type)).toEqual(["Ready", "Synced"]);
+  });
+
+  test("treats invalid or missing timestamps as epoch 0", () => {
+    const withTime = condition({ type: "Ready", lastTransitionTime: "2024-01-01T00:00:00Z" });
+    const withoutTime = condition({ type: "Initialized", lastTransitionTime: undefined });
+    expect(sortConditions([withoutTime, withTime])?.[0].type).toBe("Ready");
+  });
+
+  test("honours a custom priority map on ties", () => {
+    const time = "2024-01-01T00:00:00Z";
+    const a = condition({ type: "A", lastTransitionTime: time });
+    const b = condition({ type: "B", lastTransitionTime: time });
+    expect(sortConditions([a, b], { A: 1, B: 2 })?.map((c) => c.type)).toEqual(["B", "A"]);
+  });
+});
+
+describe("getLastCondition", () => {
+  test("returns the newest condition", () => {
+    const older = condition({ type: "Initialized", lastTransitionTime: "2024-01-01T00:00:00Z" });
+    const newer = condition({ type: "Ready", lastTransitionTime: "2024-01-02T00:00:00Z" });
+    expect(getLastCondition([older, newer])?.type).toBe("Ready");
+  });
+
+  test("returns undefined for an empty list", () => {
+    expect(getLastCondition([])).toBeUndefined();
+  });
+});
+
+describe("getConditionText", () => {
+  test("returns Unknown for missing or empty conditions", () => {
+    expect(getConditionText()).toBe("Unknown");
+    expect(getConditionText([])).toBe("Unknown");
+  });
+
+  test("returns Ready when the latest condition is Ready/True", () => {
+    expect(getConditionText([condition({ type: "Ready", status: "True" })])).toBe("Ready");
+  });
+
+  test("returns Not Ready when the latest condition status is False", () => {
+    expect(getConditionText([condition({ type: "Ready", status: "False" })])).toBe("Not Ready");
+  });
+
+  test("returns Stalled when the latest condition type is Stalled", () => {
+    expect(getConditionText([condition({ type: "Stalled", status: "Unknown" })])).toBe("Stalled");
+  });
+
+  test("returns In Progress for a non-terminal, non-Ready condition", () => {
+    expect(getConditionText([condition({ type: "Reconciling", status: "Unknown" })])).toBe("In Progress");
+  });
+});
+
+describe("getStatusMessage", () => {
+  test("returns the message of the newest condition", () => {
+    const older = condition({ type: "Initialized", lastTransitionTime: "2024-01-01T00:00:00Z", message: "old" });
+    const newer = condition({ type: "Ready", lastTransitionTime: "2024-01-02T00:00:00Z", message: "new" });
+    expect(getStatusMessage([older, newer])).toBe("new");
+  });
+
+  test("returns undefined for missing or empty conditions", () => {
+    expect(getStatusMessage()).toBeUndefined();
+    expect(getStatusMessage([])).toBeUndefined();
+  });
+});
+
+describe("getConditionClass", () => {
+  test.each([
+    ["True", "Ready", "success"],
+    ["False", "Ready", "error"],
+    ["Unknown", "Reconciling", "warning"],
+  ])("maps status %s / type %s to the %s class", (status, type, expected) => {
+    expect(getConditionClass([condition({ type, status } as Partial<Condition>)])).toBe(expected);
+  });
+
+  test("returns an empty class for unknown status", () => {
+    expect(getConditionClass()).toBe("");
+    expect(getConditionClass([])).toBe("");
+  });
+});
+
+describe("getLastUpdated", () => {
+  test("returns the transition time of the newest condition", () => {
+    const older = condition({ type: "Initialized", lastTransitionTime: "2024-01-01T00:00:00Z" });
+    const newer = condition({ type: "Ready", lastTransitionTime: "2024-01-02T00:00:00Z" });
+    expect(getLastUpdated([older, newer])).toBe("2024-01-02T00:00:00Z");
+  });
+
+  test("returns undefined for missing or empty conditions", () => {
+    expect(getLastUpdated()).toBeUndefined();
+    expect(getLastUpdated([])).toBeUndefined();
+  });
+});

--- a/src/renderer/k8s/fluxcd/helm/helmrelease-v2.test.ts
+++ b/src/renderer/k8s/fluxcd/helm/helmrelease-v2.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import { HelmRelease } from "./helmrelease-v2";
+
+describe("HelmRelease.getAppVersion / getChartVersion", () => {
+  test("reads the app version from the newest history entry", () => {
+    const object = { status: { history: [{ appVersion: "1.2.3" }] } } as unknown as HelmRelease;
+    expect(HelmRelease.getAppVersion(object)).toBe("1.2.3");
+  });
+
+  test("prefers the history chart version over the spec version", () => {
+    const object = {
+      status: { history: [{ chartVersion: "2.0.0" }] },
+      spec: { chart: { spec: { version: "1.0.0" } } },
+    } as unknown as HelmRelease;
+    expect(HelmRelease.getChartVersion(object)).toBe("2.0.0");
+  });
+
+  test("falls back to the spec chart version when there is no history", () => {
+    const object = { status: {}, spec: { chart: { spec: { version: "1.0.0" } } } } as unknown as HelmRelease;
+    expect(HelmRelease.getChartVersion(object)).toBe("1.0.0");
+  });
+});
+
+describe("HelmRelease.getReleaseName", () => {
+  test("uses spec.releaseName when set", () => {
+    const object = { metadata: { name: "hr" }, spec: { releaseName: "custom" } } as unknown as HelmRelease;
+    expect(HelmRelease.getReleaseName(object)).toBe("custom");
+  });
+
+  test("prefixes the target namespace when there is no release name", () => {
+    const object = { metadata: { name: "hr" }, spec: { targetNamespace: "apps" } } as unknown as HelmRelease;
+    expect(HelmRelease.getReleaseName(object)).toBe("apps-hr");
+  });
+
+  test("falls back to the metadata name", () => {
+    const object = { metadata: { name: "hr" }, spec: {} } as unknown as HelmRelease;
+    expect(HelmRelease.getReleaseName(object)).toBe("hr");
+  });
+});
+
+describe("HelmRelease.getReleaseNameShortened", () => {
+  test("leaves short names untouched", () => {
+    const object = { metadata: { name: "short" }, spec: {} } as unknown as HelmRelease;
+    expect(HelmRelease.getReleaseNameShortened(object)).toBe("short");
+  });
+
+  test("truncates and appends a hash for names longer than 53 characters", () => {
+    const name = "a".repeat(60);
+    const object = { metadata: { name }, spec: {} } as unknown as HelmRelease;
+    const result = HelmRelease.getReleaseNameShortened(object);
+    expect(result).toMatch(/^a{40}-[0-9a-f]{12}$/);
+    expect(result.length).toBe(53);
+  });
+});
+
+describe("HelmRelease.getHelmChartName", () => {
+  test("joins the chart namespace and the object name", () => {
+    const object = {
+      metadata: { name: "hr" },
+      spec: { chart: { spec: { sourceRef: { namespace: "flux-system" } } } },
+    } as unknown as HelmRelease;
+    expect(HelmRelease.getHelmChartName(object)).toBe("flux-system-hr");
+  });
+});
+
+describe("HelmRelease.getSourceRefText", () => {
+  test("formats the chart source ref", () => {
+    const object = {
+      spec: { chart: { spec: { sourceRef: { kind: "HelmRepository", namespace: "flux-system", name: "repo" } } } },
+    } as unknown as HelmRelease;
+    expect(HelmRelease.getSourceRefText(object)).toBe("HelmRepository: flux-system/repo");
+  });
+
+  test("falls back to chartRef when there is no inline chart", () => {
+    const object = {
+      spec: { chartRef: { kind: "OCIRepository", name: "oci" } },
+    } as unknown as HelmRelease;
+    expect(HelmRelease.getSourceRefText(object)).toBe("OCIRepository: oci");
+  });
+});

--- a/src/renderer/k8s/fluxcd/kustomize/kustomization-v1.test.ts
+++ b/src/renderer/k8s/fluxcd/kustomize/kustomization-v1.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { Kustomization } from "./kustomization-v1";
+
+describe("Kustomization.getLastAppliedRevision", () => {
+  test("returns undefined when there is no applied revision", () => {
+    expect(Kustomization.getLastAppliedRevision({ status: {} } as unknown as Kustomization)).toBeUndefined();
+  });
+
+  test("strips a refs/heads/ prefix", () => {
+    const object = { status: { lastAppliedRevision: "refs/heads/main@sha1:abc" } } as unknown as Kustomization;
+    expect(Kustomization.getLastAppliedRevision(object)).toBe("main@sha1:abc");
+  });
+});
+
+describe("Kustomization.getSourceRefText", () => {
+  test("formats kind and name without a namespace", () => {
+    const object = { spec: { sourceRef: { kind: "GitRepository", name: "app" } } } as unknown as Kustomization;
+    expect(Kustomization.getSourceRefText(object)).toBe("GitRepository: app");
+  });
+
+  test("includes the namespace when present", () => {
+    const object = {
+      spec: { sourceRef: { kind: "GitRepository", namespace: "flux-system", name: "app" } },
+    } as unknown as Kustomization;
+    expect(Kustomization.getSourceRefText(object)).toBe("GitRepository: flux-system/app");
+  });
+});
+
+describe("Kustomization.getSourceRefUrl", () => {
+  test("builds an API link from the source ref", () => {
+    const object = { spec: { sourceRef: { kind: "GitRepository", name: "app" } } } as unknown as Kustomization;
+    expect(Kustomization.getSourceRefUrl(object)).toBe("/apis/GitRepository/app");
+  });
+});

--- a/src/renderer/k8s/fluxcd/source/gitrepository-v1.test.ts
+++ b/src/renderer/k8s/fluxcd/source/gitrepository-v1.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { GitRepository } from "./gitrepository-v1";
+
+import type { GitRepositoryRef } from "./gitrepository-v1";
+
+describe("GitRepository.getGitRef", () => {
+  test("returns undefined when there is no ref", () => {
+    expect(GitRepository.getGitRef(undefined)).toBeUndefined();
+  });
+
+  test("strips the refs/heads/ prefix from a name", () => {
+    expect(GitRepository.getGitRef({ name: "refs/heads/main" })).toBe("main");
+  });
+
+  test("strips the refs/tags/ prefix from a name", () => {
+    expect(GitRepository.getGitRef({ name: "refs/tags/v1.0.0" })).toBe("v1.0.0");
+  });
+
+  test("prefers name over the other fields", () => {
+    expect(GitRepository.getGitRef({ name: "custom", branch: "main", tag: "v1" })).toBe("custom");
+  });
+
+  test.each<[keyof GitRepositoryRef, string]>([
+    ["branch", "main"],
+    ["tag", "v1.2.3"],
+    ["semver", ">=1.0.0"],
+    ["commit", "abcdef"],
+  ])("falls back to %s when no name is set", (field, value) => {
+    expect(GitRepository.getGitRef({ [field]: value })).toBe(value);
+  });
+});
+
+describe("GitRepository.getGitRefFull", () => {
+  test("returns undefined for an empty or missing ref", () => {
+    expect(GitRepository.getGitRefFull(undefined)).toBeUndefined();
+    expect(GitRepository.getGitRefFull({})).toBeUndefined();
+  });
+
+  test.each<[keyof GitRepositoryRef, string, string]>([
+    ["name", "refs/heads/main", "name: refs/heads/main"],
+    ["branch", "main", "branch: main"],
+    ["tag", "v1", "tag: v1"],
+    ["semver", ">=1.0.0", "semver: >=1.0.0"],
+    ["commit", "abcdef", "commit: abcdef"],
+  ])("labels the %s field", (field, value, expected) => {
+    expect(GitRepository.getGitRefFull({ [field]: value })).toBe(expected);
+  });
+
+  test("prefers name over other fields", () => {
+    expect(GitRepository.getGitRefFull({ name: "n", branch: "b" })).toBe("name: n");
+  });
+});
+
+describe("GitRepository.getGitRevision", () => {
+  test("returns undefined when there is no artifact revision", () => {
+    expect(GitRepository.getGitRevision({ status: {} } as unknown as GitRepository)).toBeUndefined();
+  });
+
+  test("strips the refs/heads/ prefix from the revision", () => {
+    const object = { status: { artifact: { revision: "refs/heads/main@sha1:abc" } } } as unknown as GitRepository;
+    expect(GitRepository.getGitRevision(object)).toBe("main@sha1:abc");
+  });
+
+  test("leaves a revision without a refs prefix untouched", () => {
+    const object = { status: { artifact: { revision: "main@sha1:abc" } } } as unknown as GitRepository;
+    expect(GitRepository.getGitRevision(object)).toBe("main@sha1:abc");
+  });
+});

--- a/src/renderer/utils.test.ts
+++ b/src/renderer/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { createEnumFromKeys, createHash, getHeight } from "./utils";
+
+describe("createHash", () => {
+  test("is a 16-character lowercase hex string", () => {
+    expect(createHash({ a: 1 })).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("is stable for equal input", () => {
+    expect(createHash({ a: 1 })).toBe(createHash({ a: 1 }));
+  });
+
+  test("differs for different input", () => {
+    expect(createHash({ a: 1 })).not.toBe(createHash({ a: 2 }));
+  });
+
+  test("is sensitive to key order, matching JSON.stringify semantics", () => {
+    expect(createHash({ a: 1, b: 2 })).not.toBe(createHash({ b: 2, a: 1 }));
+  });
+
+  test("handles primitive and array input", () => {
+    expect(createHash("hello")).toMatch(/^[0-9a-f]{16}$/);
+    expect(createHash([1, 2, 3])).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("getHeight", () => {
+  test("returns a single line height when there is no data", () => {
+    expect(getHeight()).toBe(18);
+    expect(getHeight("")).toBe(18);
+  });
+
+  test("clamps short content to a minimum of five lines", () => {
+    expect(getHeight("one\ntwo")).toBe(5 * 18);
+  });
+
+  test("scales with the number of lines between the bounds", () => {
+    const data = Array.from({ length: 10 }, (_, i) => `line ${i}`).join("\n");
+    expect(getHeight(data)).toBe(10 * 18);
+  });
+
+  test("clamps long content to a maximum of twenty lines", () => {
+    const data = Array.from({ length: 50 }, (_, i) => `line ${i}`).join("\n");
+    expect(getHeight(data)).toBe(20 * 18);
+  });
+});
+
+describe("createEnumFromKeys", () => {
+  test("maps each key to itself", () => {
+    expect(createEnumFromKeys({ foo: 1, bar: "x" })).toEqual({ foo: "foo", bar: "bar" });
+  });
+
+  test("returns an empty object for an empty input", () => {
+    expect(createEnumFromKeys({})).toEqual({});
+  });
+});

--- a/test/stubs/freelensapp-extensions.ts
+++ b/test/stubs/freelensapp-extensions.ts
@@ -1,0 +1,36 @@
+// Minimal stub for `@freelensapp/extensions`.
+//
+// The real module is the Freelens host renderer bundle, which expects a browser
+// environment and cannot be imported under the Node-based vitest runner. Unit
+// tests only exercise pure logic (utility functions and `static` CRD helpers),
+// so this stub provides just enough of the `Renderer` surface for the extension
+// modules to load: the base classes the CRD models extend and the few host APIs
+// referenced by the helpers under test.
+
+class LensExtensionKubeObject {
+  metadata: Record<string, unknown> = {};
+  spec: Record<string, unknown> = {};
+  status: Record<string, unknown> = {};
+
+  constructor(data?: Record<string, unknown>) {
+    if (data) Object.assign(this, data);
+  }
+}
+
+class KubeApi {}
+class KubeObjectStore {}
+
+export const Renderer = {
+  K8sApi: {
+    LensExtensionKubeObject,
+    KubeApi,
+    KubeObjectStore,
+    apiManager: {
+      // Returns a deterministic value so tests can assert that a link was built.
+      lookupApiLink: (ref: { kind?: string; name?: string }) => `/apis/${ref?.kind ?? "Unknown"}/${ref?.name ?? ""}`,
+    },
+  },
+  Navigation: {
+    getDetailsUrl: (url: string) => `/details?url=${encodeURIComponent(url)}`,
+  },
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    exclude: ["integration/**", "node_modules/**", "out/**"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    passWithNoTests: true,
+    alias: {
+      // The real `@freelensapp/extensions` is the Freelens host renderer bundle
+      // which needs a browser; swap it for a lightweight stub so extension
+      // modules can be imported and their pure logic exercised under Node.
+      "@freelensapp/extensions": resolve(__dirname, "test/stubs/freelensapp-extensions.ts"),
+    },
+  },
+});


### PR DESCRIPTION
Ports the vitest unit-test setup from freelens-gateway-api-extension and adds an initial suite (64 tests) covering utility and CRD helper logic.

Resolves #264.
