### PR TITLE
Use Ready condition for status badge instead of newest condition

### DIFF
--- a/src/renderer/components/status-conditions.test.ts
+++ b/src/renderer/components/status-conditions.test.ts
@@ -81,6 +81,12 @@ describe("getConditionText", () => {
   test("returns In Progress for a non-terminal, non-Ready condition", () => {
     expect(getConditionText([condition({ type: "Reconciling", status: "Unknown" })])).toBe("In Progress");
   });
+
+  test("returns Ready when Ready/True even if a newer condition is False (drift detection)", () => {
+    const ready = condition({ type: "Ready", status: "True", lastTransitionTime: "2024-01-01T00:00:00Z" });
+    const drift = condition({ type: "Released", status: "False", lastTransitionTime: "2024-01-02T00:00:00Z" });
+    expect(getConditionText([ready, drift])).toBe("Ready");
+  });
 });
 
 describe("getStatusMessage", () => {

--- a/src/renderer/components/status-conditions.ts
+++ b/src/renderer/components/status-conditions.ts
@@ -39,13 +39,25 @@ export function getLastCondition(conditions: Condition[]): Condition | undefined
 
 export function getConditionText(conditions?: Condition[]) {
   if (!conditions || !conditions.length) return "Unknown";
-  const condition = getLastCondition(conditions);
   if ("suspend" in conditions && conditions.suspend) return "Suspended";
-  if (condition?.type === "Ready" && condition?.status === "True") return "Ready";
+
+  // The Ready condition is the canonical overall status for FluxCD resources
+  // (kstatus / flux CLI). Prefer it over the newest condition; otherwise an
+  // unrelated newer condition (e.g. from drift detection) with status False
+  // would incorrectly mark a Ready resource as Not Ready.
+  const readyCondition = conditions.find((condition) => condition.type === "Ready");
+  if (readyCondition) {
+    if (readyCondition.status === "True") return "Ready";
+    if (conditions.some((condition) => condition.type === "Stalled" && condition.status === "True")) return "Stalled";
+    if (readyCondition.status === "False") return "Not Ready";
+    return "In Progress";
+  }
+
+  // No Ready condition yet: fall back to the newest-condition heuristic.
+  const condition = getLastCondition(conditions);
   if (condition?.status === "False") return "Not Ready";
-  if (condition?.type == "Stalled") return "Stalled";
-  if (conditions) return "In Progress";
-  return "Unknown";
+  if (condition?.type === "Stalled") return "Stalled";
+  return "In Progress";
 }
 
 export function getStatusMessage(conditions?: Condition[]) {


### PR DESCRIPTION
Fixes #271

When drift detection is enabled on a HelmRelease, the resource can carry a newer non-Ready condition (e.g. `Released`) with status `False` while the `Ready` condition stays `True`. The badge was derived from the newest condition, so it showed "Not Ready" even though the resource was Ready.

This bases `getConditionText` on the canonical `Ready` condition (as kstatus and the flux CLI do), falling back to the newest-condition heuristic only when no `Ready` condition exists. A regression test is included.

Generated with [Claude Code](https://claude.ai/code)