### PR TITLE
Mark resource as Not Ready while a reconcile is in progress

### DIFF
--- a/src/renderer/components/status-conditions.test.ts
+++ b/src/renderer/components/status-conditions.test.ts
@@ -87,6 +87,12 @@ describe("getConditionText", () => {
     const drift = condition({ type: "Released", status: "False", lastTransitionTime: "2024-01-02T00:00:00Z" });
     expect(getConditionText([ready, drift])).toBe("Ready");
   });
+
+  test("returns Not Ready when a reconcile is in progress even if Ready/True", () => {
+    const ready = condition({ type: "Ready", status: "True", lastTransitionTime: "2024-01-01T00:00:00Z" });
+    const reconciling = condition({ type: "Reconciling", status: "True", lastTransitionTime: "2024-01-02T00:00:00Z" });
+    expect(getConditionText([ready, reconciling])).toBe("Not Ready");
+  });
 });
 
 describe("getStatusMessage", () => {

--- a/src/renderer/components/status-conditions.ts
+++ b/src/renderer/components/status-conditions.ts
@@ -41,6 +41,15 @@ export function getConditionText(conditions?: Condition[]) {
   if (!conditions || !conditions.length) return "Unknown";
   if ("suspend" in conditions && conditions.suspend) return "Suspended";
 
+  // A resource that is actively reconciling is not (yet) in its desired state.
+  // Flux sets a Reconciling condition (status True) while a reconcile is in
+  // progress, even when the Ready condition still reflects the previous
+  // success. Report it as Not Ready regardless of what the heuristic below
+  // would otherwise conclude.
+  if (conditions.some((condition) => condition.type === "Reconciling" && condition.status === "True")) {
+    return "Not Ready";
+  }
+
   // The Ready condition is the canonical overall status for FluxCD resources
   // (kstatus / flux CLI). Prefer it over the newest condition; otherwise an
   // unrelated newer condition (e.g. from drift detection) with status False


### PR DESCRIPTION
Follow-up to #281 for #271.

Flux sets a `Reconciling` condition (status `True`) while a reconcile is in progress, even when the `Ready` condition still reflects the previous success. This makes `getConditionText` report such resources as "Not Ready" so the badge reflects that they are not currently in their desired state. A regression test is included.

Generated with [Claude Code](https://claude.ai/code)