### PR TITLE
Show In Progress instead of Not Ready while a reconcile is in progress

### DIFF
--- a/src/renderer/components/status-conditions.test.ts
+++ b/src/renderer/components/status-conditions.test.ts
@@ -88,10 +88,10 @@ describe("getConditionText", () => {
     expect(getConditionText([ready, drift])).toBe("Ready");
   });
 
-  test("returns Not Ready when a reconcile is in progress even if Ready/True", () => {
+  test("returns In Progress when a reconcile is in progress even if Ready/True", () => {
     const ready = condition({ type: "Ready", status: "True", lastTransitionTime: "2024-01-01T00:00:00Z" });
     const reconciling = condition({ type: "Reconciling", status: "True", lastTransitionTime: "2024-01-02T00:00:00Z" });
-    expect(getConditionText([ready, reconciling])).toBe("Not Ready");
+    expect(getConditionText([ready, reconciling])).toBe("In Progress");
   });
 });
 

--- a/src/renderer/components/status-conditions.ts
+++ b/src/renderer/components/status-conditions.ts
@@ -44,10 +44,10 @@ export function getConditionText(conditions?: Condition[]) {
   // A resource that is actively reconciling is not (yet) in its desired state.
   // Flux sets a Reconciling condition (status True) while a reconcile is in
   // progress, even when the Ready condition still reflects the previous
-  // success. Report it as Not Ready regardless of what the heuristic below
+  // success. Report it as In Progress regardless of what the heuristic below
   // would otherwise conclude.
   if (conditions.some((condition) => condition.type === "Reconciling" && condition.status === "True")) {
-    return "Not Ready";
+    return "In Progress";
   }
 
   // The Ready condition is the canonical overall status for FluxCD resources


### PR DESCRIPTION
Follow-up to #283 for #271.

PR #283 made a resource with an active `Reconciling` condition (status `True`) show "Not Ready". Since "In Progress" is already handled in both `getConditionText` and `getConditionClass` (warning class), an in-flight reconcile now shows "In Progress" instead, which better reflects that the resource is transitioning rather than failing. The regression test was updated.

Generated with [Claude Code](https://claude.ai/code)